### PR TITLE
Feature/automate docs rst sphinx build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,11 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: 3.8
+  jobs:
+  # Build the rst files in case API has changed or modules has been added
+    pre_build:
+      - sphinx-apidoc -f -o docs/ ../dlomix/dlomix
     
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,3 +22,4 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
   jobs:
   # Build the rst files in case API has changed or modules has been added
     pre_build:
-      - sphinx-apidoc -f -o docs/ ../dlomix/dlomix
+      - sphinx-apidoc -f -o docs/ dlomix/
     
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: 3.8
+    python: "3.8"
   jobs:
   # Build the rst files in case API has changed or modules has been added
     pre_build:


### PR DESCRIPTION
## Changes:
- add a pre-build step to readthedocs to re-generate rst files for modules
- any API changes or new modules will automatically be indexed

## Notes:
- probably later we can remove the *.rst files under `/docs/`, they should be automatically generated and used for the docs