### PR TITLE
Feature/prosit-ptm-model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ install-dev:
 .PHONY: test
 test:
 	mkdir -p cov/
+
 	python -m pytest tests/ --junitxml=junit/test-results.xml --cov=dlomix --cov-report html:cov/cov_html --cov-report xml:cov/cov.xml --cov-report lcov:cov/cov.info --cov-report annotate:cov/cov_annotate
 
 format:
-	black ./dlomix/*
+	black ./dlomix/*.py
+	black ./run_scripts/*.py
+	black ./tests/*.py
+
 
 lint:
 	pylint --disable=R,C ./dlomix/*

--- a/dlomix/models/prosit.py
+++ b/dlomix/models/prosit.py
@@ -3,7 +3,6 @@ from tensorflow.keras.layers.experimental import preprocessing
 from dlomix.constants import ALPHABET_UNMOD
 from dlomix.layers.attention import AttentionLayer, DecoderAttentionLayer
 
-
 class PrositRetentionTimePredictor(tf.keras.Model):
     """Implementation of the Prosit model for retention time prediction.
 
@@ -123,7 +122,22 @@ class PrositIntensityPredictor(tf.keras.Model):
         "PRECURSOR_CHARGE_KEY",
         "FRAGMENTATION_TYPE_KEY",
     ]
-    PTM_INPUT_KEYS = ["ptm_atom_count_loss", "ptm_atom_count_gain"]
+    PTM_INPUT_KEYS = ["ptm_atom_count_loss", "ptm_atom_count_gain", "ptm_location"]
+
+
+    # ToDo: 
+#     ptm_loc_in = Input(shape=(PEP_IN, 1, ), dtype='int32', name="ptm_closest_atom")
+#
+#     # > Process PTMs (location and atom count loss and gain)
+#     ptm_ac_loss_gain = Concatenate(name="ptm_ac_loss_gain")([ptm_ac_gain_in, ptm_ac_loss_in])
+#     ptm_ac_diff_loc = Concatenate(name="ptm_ac_diff_loc")([ptm_ac_loss_gain, ptm_loc_in])
+#     ptm_ac_diff_dense = Dense(LATENT//2, name='ptm_ac_diff_dense')(ptm_ac_diff_loc)
+#     ptm_ac_diff_do = Dropout(DROPOUT_RATE, name='ptm_ac_diff_do')(ptm_ac_diff_dense)
+#     tm_ac_diff_dense_2 = Dense(EMBEDDING_OUT*4, name='tm_ac_diff_dense_2')(ptm_ac_diff_do)
+#     ptm_ac_diff_do_2 = Dropout(DROPOUT_RATE, name='ptm_ac_diff_do_2')(tm_ac_diff_dense_2)
+#     tm_ac_diff_dense_3 = Dense(EMBEDDING_OUT, name='tm_ac_diff_dense_3')(ptm_ac_diff_do_2)
+#     ptm_ac_diff_do_3 = Dropout(DROPOUT_RATE, name='ptm_ac_diff_do_3')(tm_ac_diff_dense_3)
+
 
     def __init__(
         self,

--- a/dlomix/models/prosit.py
+++ b/dlomix/models/prosit.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
-from tensorflow.keras.layers.experimental import preprocessing
 from dlomix.constants import ALPHABET_UNMOD
 from dlomix.layers.attention import AttentionLayer, DecoderAttentionLayer
+from tensorflow.keras.layers.experimental import preprocessing
 
 
 class PrositRetentionTimePredictor(tf.keras.Model):

--- a/dlomix/models/prosit.py
+++ b/dlomix/models/prosit.py
@@ -11,7 +11,7 @@ class PrositRetentionTimePredictor(tf.keras.Model):
     -----------
         embedding_output_dim (int, optional): Size of the embeddings to use. Defaults to 16.
         seq_length (int, optional): Sequence length of the peptide sequences. Defaults to 30.
-        vocab_dict (dict, optional): Dictionary mapping for the vocabulary (the amino acids in this case). Defaults to ALPHABET_UNMOD.
+        vocab_dict (dict, optional): Dictionary mapping for the vocabulary (the amino acids in this case).  Defaults to None, which is mapped to `ALPHABET_UNMOD`.
         dropout_rate (float, optional): Probability to use for dropout layers in the encoder. Defaults to 0.5.
         latent_dropout_rate (float, optional): Probability to use for dropout layers in the regressor layers after encoding. Defaults to 0.1.
         recurrent_layers_sizes (tuple, optional): A tuple of 2 values for the sizes of the two GRU layers in the encoder. Defaults to (256, 512).
@@ -22,7 +22,7 @@ class PrositRetentionTimePredictor(tf.keras.Model):
         self,
         embedding_output_dim=16,
         seq_length=30,
-        vocab_dict=ALPHABET_UNMOD,
+        vocab_dict=None,
         dropout_rate=0.5,
         latent_dropout_rate=0.1,
         recurrent_layers_sizes=(256, 512),
@@ -30,16 +30,21 @@ class PrositRetentionTimePredictor(tf.keras.Model):
     ):
         super(PrositRetentionTimePredictor, self).__init__()
 
-        # tie the count of embeddings to the size of the vocabulary (count of amino acids)
-        self.embeddings_count = len(vocab_dict) + 2
-
         self.dropout_rate = dropout_rate
         self.latent_dropout_rate = latent_dropout_rate
         self.regressor_layer_size = regressor_layer_size
         self.recurrent_layers_sizes = recurrent_layers_sizes
 
+        if vocab_dict:
+            self.vocab_dict = vocab_dict
+        else:
+            self.vocab_dict = ALPHABET_UNMOD
+
+        # tie the count of embeddings to the size of the vocabulary (count of amino acids)
+        self.embeddings_count = len(self.vocab_dict) + 2
+
         self.string_lookup = preprocessing.StringLookup(
-            vocabulary=list(vocab_dict.keys())
+            vocabulary=list(self.vocab_dict.keys())
         )
 
         self.embedding = tf.keras.layers.Embedding(
@@ -93,28 +98,48 @@ class PrositIntensityPredictor(tf.keras.Model):
     -----------
         embedding_output_dim (int, optional): Size of the embeddings to use. Defaults to 16.
         seq_length (int, optional): Sequence length of the peptide sequences. Defaults to 30.
-        vocab_dict (dict, optional): Dictionary mapping for the vocabulary (the amino acids in this case). Defaults to ALPHABET_UNMOD.
+        vocab_dict (dict, optional): Dictionary mapping for the vocabulary (the amino acids in this case). Defaults to None, which is mapped to `ALPHABET_UNMOD`.
         dropout_rate (float, optional): Probability to use for dropout layers in the encoder. Defaults to 0.5.
         latent_dropout_rate (float, optional): Probability to use for dropout layers in the regressor layers after encoding. Defaults to 0.1.
         recurrent_layers_sizes (tuple, optional): A tuple of 2 values for the sizes of the two GRU layers in the encoder. Defaults to (256, 512).
         regressor_layer_size (int, optional): Size of the dense layer in the regressor after the encoder. Defaults to 512.
+        use_ptm_counts (boolean, optional): Whether to use PTM counts and create corresponding layers, has to be aligned with input_keys. Defaults to False.
+        input_keys (dict, optional): dict of string keys and values mapping a fixed key to a value key in the inputs dict from the dataset class. Defaults to None, which corresponds then to the required default input keys `DEFAULT_INPUT_KEYS`.
+        meta_data_keys (list, optional): list of string values corresponding to fixed keys in the inputs dict that are considered meta data. Defaults to None, which corresponds then to the default meta data keys `META_DATA_KEYS`.
     """
+
+    # consider using kwargs in the call function instead !
+
+    DEFAULT_INPUT_KEYS = {
+        "SEQUENCE_KEY": "sequence",
+        "COLLISION_ENERGY_KEY": "collision_energy",
+        "PRECURSOR_CHARGE_KEY": "precursor_charge",
+        "FRAGMENTATION_TYPE_KEY": "fragmentation_type",
+    }
+
+    # can be extended to include all possible meta data
+    META_DATA_KEYS = [
+        "COLLISION_ENERGY_KEY",
+        "PRECURSOR_CHARGE_KEY",
+        "FRAGMENTATION_TYPE_KEY",
+    ]
+    PTM_INPUT_KEYS = ["ptm_atom_count_loss", "ptm_atom_count_gain"]
 
     def __init__(
         self,
         embedding_output_dim=16,
         seq_length=30,
         len_fion=6,
-        vocab_dict=ALPHABET_UNMOD,
+        vocab_dict=None,
         dropout_rate=0.2,
         latent_dropout_rate=0.1,
         recurrent_layers_sizes=(256, 512),
         regressor_layer_size=512,
+        use_ptm_counts=False,
+        input_keys=None,
+        meta_data_keys=None,
     ):
         super(PrositIntensityPredictor, self).__init__()
-
-        # tie the count of embeddings to the size of the vocabulary (count of amino acids)
-        self.embeddings_count = len(vocab_dict) + 2
 
         self.dropout_rate = dropout_rate
         self.latent_dropout_rate = latent_dropout_rate
@@ -122,12 +147,23 @@ class PrositIntensityPredictor(tf.keras.Model):
         self.recurrent_layers_sizes = recurrent_layers_sizes
         self.seq_length = seq_length
         self.len_fion = len_fion
+        self.use_ptm_counts = use_ptm_counts
+        self.input_keys = input_keys
+        self.meta_data_keys = meta_data_keys
 
         # maximum number of fragment ions
         self.max_ion = self.seq_length - 1
 
+        if vocab_dict:
+            self.vocab_dict = vocab_dict
+        else:
+            self.vocab_dict = ALPHABET_UNMOD
+
+        # tie the count of embeddings to the size of the vocabulary (count of amino acids)
+        self.embeddings_count = len(self.vocab_dict) + 2
+
         self.string_lookup = preprocessing.StringLookup(
-            vocabulary=list(vocab_dict.keys())
+            vocabulary=list(self.vocab_dict.keys())
         )
 
         self.embedding = tf.keras.layers.Embedding(
@@ -136,12 +172,18 @@ class PrositIntensityPredictor(tf.keras.Model):
             input_length=seq_length,
         )
 
+        if self.input_keys is None:
+            self.input_keys = PrositIntensityPredictor.DEFAULT_INPUT_KEYS
+
+        if self.meta_data_keys is None:
+            self.meta_data_keys = PrositIntensityPredictor.META_DATA_KEYS
+
         self._build_encoders()
         self._build_decoder()
 
         self.attention = AttentionLayer(name="encoder_att")
 
-        self.fusion_layer = tf.keras.Sequential(
+        self.meta_data_fusion_layer = tf.keras.Sequential(
             [
                 tf.keras.layers.Multiply(name="add_meta"),
                 tf.keras.layers.RepeatVector(self.max_ion, name="repeat"),
@@ -184,6 +226,26 @@ class PrositIntensityPredictor(tf.keras.Model):
                 tf.keras.layers.Dropout(rate=self.dropout_rate),
             ]
         )
+        if not self.use_ptm_counts:
+            self.ptm_encoder, self.ptm_aa_fusion = None, None
+        else:
+            self.ptm_encoder = tf.keras.Sequential(
+                [
+                    tf.keras.layers.Concatenate(name="ptm_ac_loss_gain"),
+                    tf.keras.layers.Bidirectional(
+                        tf.keras.layers.GRU(
+                            units=self.recurrent_layers_sizes[0], return_sequences=True
+                        )
+                    ),
+                    tf.keras.layers.Dropout(rate=self.dropout_rate),
+                    tf.keras.layers.GRU(
+                        units=self.recurrent_layers_sizes[1], return_sequences=True
+                    ),
+                    tf.keras.layers.Dropout(rate=self.dropout_rate),
+                ]
+            )
+
+            self.ptm_aa_fusion = tf.keras.layers.Multiply(name="aa_ptm_in")
 
     def _build_decoder(self):
         self.decoder = tf.keras.Sequential(
@@ -199,22 +261,42 @@ class PrositIntensityPredictor(tf.keras.Model):
         )
 
     def call(self, inputs, **kwargs):
-        peptides_in = inputs["sequence"]
-        collision_energy_in = inputs["collision_energy"]
-        precursor_charge_in = inputs["precursor_charge"]
+        peptides_in = inputs.get(self.input_keys["SEQUENCE_KEY"])
 
-        encoded_meta = self.meta_encoder([collision_energy_in, precursor_charge_in])
+        # read meta data from the input dict
+        meta_data = []
+        # note that the value here is the key to use in the inputs dict passed from the dataset
+        for meta_key, key_in_inputs in self.input_keys.items():
+            if meta_key in PrositIntensityPredictor.META_DATA_KEYS:
+                # get the input under the specified key if exists
+                meta_in = inputs.get(key_in_inputs, None)
+                if meta_in is not None:
+                    # add the input to the list of meta data inputs
+                    meta_data.append(meta_in)
+
+        if self.meta_encoder and len(meta_data) > 0:
+            encoded_meta = self.meta_encoder(meta_data)
+
+        # read PTM atom count features from the input dict
+        ptm_ac_features = []
+        for ptm_key in PrositIntensityPredictor.PTM_INPUT_KEYS:
+            ptm_ac_f = inputs.get(ptm_key, None)
+            if ptm_ac_f is not None:
+                ptm_ac_features.append(ptm_ac_f)
+
+        if self.ptm_encoder and len(ptm_ac_features) > 0:
+            encoded_ptm = self.ptm_encoder(ptm_ac_features)
 
         x = self.string_lookup(peptides_in)
-        print("encoded sequence: ", x)
         x = self.embedding(x)
         x = self.sequence_encoder(x)
+
+        if self.use_ptm_counts and self.ptm_aa_fusion:
+            x = self.ptm_aa_fusion([x, encoded_ptm])
+
         x = self.attention(x)
-
-        x = self.fusion_layer([x, encoded_meta])
-
+        x = self.meta_data_fusion_layer([x, encoded_meta])
         x = self.decoder(x)
-
         x = self.regressor(x)
 
         return x

--- a/run_scripts/run_deeplc.py
+++ b/run_scripts/run_deeplc.py
@@ -9,21 +9,26 @@ from dlomix.models.deepLC import DeepLCRetentionTimePredictor
 model = DeepLCRetentionTimePredictor(seq_length=50)
 opt = tf.keras.optimizers.SGD(learning_rate=1e-4, momentum=0.9)
 
-model.compile(optimizer=opt,
-              loss='mse',
-              metrics=['mean_absolute_error', TimeDeltaMetric()])
+model.compile(
+    optimizer=opt, loss="mse", metrics=["mean_absolute_error", TimeDeltaMetric()]
+)
 
 
-DATAPATH = '../example_dataset/proteomTools_train_val.csv'
+DATAPATH = "../example_dataset/proteomTools_train_val.csv"
 
-d = RetentionTimeDataset(data_source=DATAPATH, seq_length=50, batch_size=512, val_ratio=0.2,
-                         path_aminoacid_atomcounts="./lookups/aa_comp_rel.csv")
+d = RetentionTimeDataset(
+    data_source=DATAPATH,
+    seq_length=50,
+    batch_size=512,
+    val_ratio=0.2,
+    path_aminoacid_atomcounts="./lookups/aa_comp_rel.csv",
+)
 
-history = model.fit(d.tf_dataset['train'], epochs=3, validation_data=d.tf_dataset['val'])
+history = model.fit(
+    d.tf_dataset["train"], epochs=3, validation_data=d.tf_dataset["val"]
+)
 
-model.save_weights('./output/deeplc_test')
+model.save_weights("./output/deeplc_test")
 
-with open("./history_deeplc.pkl", 'wb') as f:
-   pickle.dump(history.history, f)
-
-
+with open("./history_deeplc.pkl", "wb") as f:
+    pickle.dump(history.history, f)

--- a/run_scripts/run_pipeline.py
+++ b/run_scripts/run_pipeline.py
@@ -5,43 +5,49 @@ from dlomix.eval import TimeDeltaMetric
 # data path
 from dlomix.models import RetentionTimePredictor
 
-DATAPATH = '../example_dataset/proteomTools_train_val.csv'
+DATAPATH = "../example_dataset/proteomTools_train_val.csv"
 
-'''
+"""
 create dataset:
     - abstracts TF Dataset
     - splits sequences
     - padds sequences to the specified length
     - performs train/val split if needed
-'''
-d = RetentionTimeDataset(data_source=DATAPATH, sequence_col="sequence", target_col="irt",
-                         seq_length=40, normalize_targets=True,
-                         batch_size=128, val_ratio=0.2)
+"""
+d = RetentionTimeDataset(
+    data_source=DATAPATH,
+    sequence_col="sequence",
+    target_col="irt",
+    seq_length=40,
+    normalize_targets=True,
+    batch_size=128,
+    val_ratio=0.2,
+)
 
 
-'''
+"""
 create Model:
     - abstracts a RT Prediction Model
     - encoding to integers happens at beginning of the model
     - model has three main parts (embedding, encoder, regressor) with some parametrization
-    '''
+    """
 
-model = RetentionTimePredictor(embedding_dim=50, seq_length=40, encoder='lstm')
+model = RetentionTimePredictor(embedding_dim=50, seq_length=40, encoder="lstm")
 
 
-''''
+"""'
 
 Target is to always have the high-level model functions callabe to abstract out training, but still people
 can write their own custom training loops since the model extends tf.keras.Model
 
- '''
+ """
 
-model.compile(optimizer='adam',
-              loss='mse',
-              metrics=['mean_absolute_error', TimeDeltaMetric()])
+model.compile(
+    optimizer="adam", loss="mse", metrics=["mean_absolute_error", TimeDeltaMetric()]
+)
 
 history = model.fit(d.train_data, epochs=15, validation_data=d.val_data)
 
-'''
+"""
 
-'''
+"""

--- a/run_scripts/run_prosit_intensity.py
+++ b/run_scripts/run_prosit_intensity.py
@@ -17,25 +17,31 @@ model = PrositIntensityPredictor(seq_length=30)
 
 optimizer = tf.keras.optimizers.Adam(learning_rate=0.0001, decay=1e-7)
 
-TRAIN_DATAPATH = '../example_dataset/intensity/intensity_data.csv'
-#TEST_DATAPATH = '../example_dataset/proteomTools_test.csv'
+TRAIN_DATAPATH = "../example_dataset/intensity/intensity_data.csv"
+# TEST_DATAPATH = '../example_dataset/proteomTools_test.csv'
 
-d = IntensityDataset(data_source=TRAIN_DATAPATH, seq_length=30, batch_size=128, val_ratio=0.3)
+d = IntensityDataset(
+    data_source=TRAIN_DATAPATH, seq_length=30, batch_size=128, val_ratio=0.3
+)
 
 # continue here: test dataset ???
 
-model.compile(optimizer=optimizer,
-              loss=masked_spectral_distance,
-              metrics=['mse'])
+model.compile(optimizer=optimizer, loss=masked_spectral_distance, metrics=["mse"])
 
 weights_file = "./prosit_intensity_test"
-checkpoint = tf.keras.callbacks.ModelCheckpoint(weights_file, save_best_only=True, save_weights_only=True)
-decay = tf.keras.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.1, patience=10, verbose=1, min_lr=0)
+checkpoint = tf.keras.callbacks.ModelCheckpoint(
+    weights_file, save_best_only=True, save_weights_only=True
+)
+decay = tf.keras.callbacks.ReduceLROnPlateau(
+    monitor="val_loss", factor=0.1, patience=10, verbose=1, min_lr=0
+)
 early_stop = tf.keras.callbacks.EarlyStopping(patience=20)
 callbacks = [checkpoint, early_stop, decay]
 
 
-history = model.fit(d.train_data, epochs=5, validation_data=d.val_data, callbacks=callbacks)
+history = model.fit(
+    d.train_data, epochs=5, validation_data=d.val_data, callbacks=callbacks
+)
 
 
 predictions = model.predict(d.val_data)

--- a/run_scripts/run_prosit_retentiontime.py
+++ b/run_scripts/run_prosit_retentiontime.py
@@ -17,26 +17,35 @@ model = PrositRetentionTimePredictor(seq_length=30)
 
 optimizer = tf.keras.optimizers.Adam(lr=0.0001, decay=1e-7)
 
-TRAIN_DATAPATH = '../example_dataset/proteomTools_train_val.csv'
-TEST_DATAPATH = '../example_dataset/proteomTools_test.csv'
+TRAIN_DATAPATH = "../example_dataset/proteomTools_train_val.csv"
+TEST_DATAPATH = "../example_dataset/proteomTools_test.csv"
 
-d = RetentionTimeDataset(data_source=TRAIN_DATAPATH, seq_length=30, batch_size=512, val_ratio=0.2)
+d = RetentionTimeDataset(
+    data_source=TRAIN_DATAPATH, seq_length=30, batch_size=512, val_ratio=0.2
+)
 
-model.compile(optimizer=optimizer,
-              loss='mse',
-              metrics=['mean_absolute_error', TimeDeltaMetric()])
+model.compile(
+    optimizer=optimizer, loss="mse", metrics=["mean_absolute_error", TimeDeltaMetric()]
+)
 
 weights_file = "./prosit_test"
-checkpoint = tf.keras.callbacks.ModelCheckpoint(weights_file, save_best_only=True, save_weights_only=True)
-decay = tf.keras.callbacks.ReduceLROnPlateau(monitor='val_loss', factor=0.1, patience=10, verbose=1, min_lr=0)
+checkpoint = tf.keras.callbacks.ModelCheckpoint(
+    weights_file, save_best_only=True, save_weights_only=True
+)
+decay = tf.keras.callbacks.ReduceLROnPlateau(
+    monitor="val_loss", factor=0.1, patience=10, verbose=1, min_lr=0
+)
 early_stop = tf.keras.callbacks.EarlyStopping(patience=20)
 callbacks = [checkpoint, early_stop, decay]
 
 
-history = model.fit(d.train_data, epochs=150, validation_data=d.val_data, callbacks=callbacks)
+history = model.fit(
+    d.train_data, epochs=150, validation_data=d.val_data, callbacks=callbacks
+)
 
-test_rtdata = RetentionTimeDataset(data_source=TEST_DATAPATH,
-                                   seq_length=30, batch_size=512, test=True)
+test_rtdata = RetentionTimeDataset(
+    data_source=TEST_DATAPATH, seq_length=30, batch_size=512, test=True
+)
 
 predictions = model.predict(test_rtdata.test_data)
 predictions = d.denormalize_targets(predictions)
@@ -48,11 +57,14 @@ report = RetentionTimeReport(output_path="./output", history=history)
 print("R2: ", report.calculate_r2(test_targets, predictions))
 
 pd.DataFrame(
-    {"sequence": test_rtdata.sequences, "irt": test_rtdata.targets, "predicted_irt": predictions}
+    {
+        "sequence": test_rtdata.sequences,
+        "irt": test_rtdata.targets,
+        "predicted_irt": predictions,
+    }
 ).to_csv("./predictions_prosit_fullrun.csv", index=False)
 
 
 # TODO: function to store and load history object, or maybe consider saving the report object
-with open("./history_prosit.pkl", 'wb') as f:
+with open("./history_prosit.pkl", "wb") as f:
     pickle.dump(history.history, f)
-

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,9 +3,9 @@ import numpy as np
 import pandas as pd
 
 
-INTENSITY_CSV_EXAMPLE_URL = 'https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.csv'
+INTENSITY_CSV_EXAMPLE_URL = "https://raw.githubusercontent.com/wilhelm-lab/dlomix/develop/example_dataset/intensity/intensity_data.csv"
 TEST_DATA_PARQUET = "./tests/assets/metadata.parquet"
-RT_PARQUET_EXAMPLE_URL = 'https://zenodo.org/record/6602020/files/TUM_missing_first_meta_data.parquet?download=1'
+RT_PARQUET_EXAMPLE_URL = "https://zenodo.org/record/6602020/files/TUM_missing_first_meta_data.parquet?download=1"
 
 
 def test_empty_rtdataset():
@@ -14,29 +14,35 @@ def test_empty_rtdataset():
     assert rtdataset.targets is None
     assert rtdataset.main_split is RetentionTimeDataset.SPLIT_NAMES[0]
 
+
 def test_simple_rtdataset():
-    rtdataset = RetentionTimeDataset(data_source=(np.array(['AAA', 'BBB']), np.array([21.5, 26.5])))
+    rtdataset = RetentionTimeDataset(
+        data_source=(np.array(["AAA", "BBB"]), np.array([21.5, 26.5]))
+    )
     assert rtdataset.sequences is not None
     assert rtdataset.targets is not None
     assert rtdataset.main_split is RetentionTimeDataset.SPLIT_NAMES[0]
 
+
 def test_parquet_rtdataset():
-    rtdataset = RetentionTimeDataset(data_source=RT_PARQUET_EXAMPLE_URL,
-                sequence_col='modified_sequence', target_col='indexed_retention_time')
+    rtdataset = RetentionTimeDataset(
+        data_source=RT_PARQUET_EXAMPLE_URL,
+        sequence_col="modified_sequence",
+        target_col="indexed_retention_time",
+    )
     assert rtdataset.sequences is not None
     assert rtdataset.targets is not None
-    assert rtdataset.main_split is RetentionTimeDataset.SPLIT_NAMES[0]  
+    assert rtdataset.main_split is RetentionTimeDataset.SPLIT_NAMES[0]
+
 
 def test_json_dict_rtdataset():
     test_data_dict = {
         "metadata": {
-            "linear rt" : [1,2,3],
-            "modified_sequence": ["ABC", "ABC", "ABC"]
+            "linear rt": [1, 2, 3],
+            "modified_sequence": ["ABC", "ABC", "ABC"],
         },
         "annotations": {},
-        "parameters": {
-            "target_column_key": "linear rt"
-        }
+        "parameters": {"target_column_key": "linear rt"},
     }
 
     pd.DataFrame(test_data_dict["metadata"]).to_parquet(TEST_DATA_PARQUET)
@@ -44,13 +50,14 @@ def test_json_dict_rtdataset():
     test_data_dict_file = {
         "metadata": TEST_DATA_PARQUET,
         "annotations": {},
-        "parameters": {
-            "target_column_key": "linear rt"
-        }
+        "parameters": {"target_column_key": "linear rt"},
     }
 
     rtdataset = RetentionTimeDataset(data_source=test_data_dict, seq_length=20)
-    rtdataset_filebased = RetentionTimeDataset(data_source=test_data_dict_file, seq_length=20)
+    rtdataset_filebased = RetentionTimeDataset(
+        data_source=test_data_dict_file, seq_length=20
+    )
+
 
 def test_empty_intensitydataset():
     intensity_dataset = IntensityDataset()
@@ -60,26 +67,208 @@ def test_empty_intensitydataset():
     assert intensity_dataset.intensities is None
     assert intensity_dataset.main_split is IntensityDataset.SPLIT_NAMES[0]
 
+
 def test_simple_intensitydataset():
-    intensity_dataset = IntensityDataset(data_source=(
-        np.array(['SVFLTFLR']),
-        np.array([0.25]),
-        np.array([[0, 1, 0, 0, 0, 0]]),
-        np.array([[0.03713018032121684, 0.0, -1.0, 0.0, 0.0, -1.0, 0.02485036943573326, 0.0, -1.0, 0.37425569938350733, 0.0, -1.0, 0.1006487907071137, 0.0, -1.0, 0.16793299234113923, 0.0, -1.0, 0.5770605328948204, 0.004866043683849902, -1.0, 0.013969858753800551, 0.0, -1.0, 0.3613063752966507, 0.004158167348899733, -1.0, 0.004756058682204546, 0.0, -1.0, 1.0, 0.05804204277785504, -1.0, 0.0, 0.0, -1.0, 0.0026942297891076857, 0.0042070812435137245, -1.0, 0.0, 0.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0]])
-    ))
+    intensity_dataset = IntensityDataset(
+        data_source=(
+            np.array(["SVFLTFLR"]),
+            np.array([0.25]),
+            np.array([[0, 1, 0, 0, 0, 0]]),
+            np.array(
+                [
+                    [
+                        0.03713018032121684,
+                        0.0,
+                        -1.0,
+                        0.0,
+                        0.0,
+                        -1.0,
+                        0.02485036943573326,
+                        0.0,
+                        -1.0,
+                        0.37425569938350733,
+                        0.0,
+                        -1.0,
+                        0.1006487907071137,
+                        0.0,
+                        -1.0,
+                        0.16793299234113923,
+                        0.0,
+                        -1.0,
+                        0.5770605328948204,
+                        0.004866043683849902,
+                        -1.0,
+                        0.013969858753800551,
+                        0.0,
+                        -1.0,
+                        0.3613063752966507,
+                        0.004158167348899733,
+                        -1.0,
+                        0.004756058682204546,
+                        0.0,
+                        -1.0,
+                        1.0,
+                        0.05804204277785504,
+                        -1.0,
+                        0.0,
+                        0.0,
+                        -1.0,
+                        0.0026942297891076857,
+                        0.0042070812435137245,
+                        -1.0,
+                        0.0,
+                        0.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                        -1.0,
+                    ]
+                ]
+            ),
+        )
+    )
 
     assert intensity_dataset.sequences is not None
     assert intensity_dataset.collision_energy is not None
     assert intensity_dataset.precursor_charge is not None
     assert intensity_dataset.intensities is not None
     assert intensity_dataset.main_split is IntensityDataset.SPLIT_NAMES[0]
+
 
 def test_csv_intensitydataset():
     intensity_dataset = IntensityDataset(data_source=INTENSITY_CSV_EXAMPLE_URL)
-    
+
     assert intensity_dataset.sequences is not None
     assert intensity_dataset.collision_energy is not None
     assert intensity_dataset.precursor_charge is not None
     assert intensity_dataset.intensities is not None
     assert intensity_dataset.main_split is IntensityDataset.SPLIT_NAMES[0]
-

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -7,8 +7,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
 # ------------------ intensity - masked spectral distance ------------------
+
 
 def test_spectral_distance_identical():
     y_true = [[0.1, 0.2, 0.3]]
@@ -20,6 +20,7 @@ def test_spectral_distance_identical():
 
     assert sa.numpy() == 0
 
+
 def test_spectral_distance_different():
     y_true = [[0.1, 0.2, 0.3]]
     y_true_tensor = tf.convert_to_tensor(y_true)
@@ -30,12 +31,14 @@ def test_spectral_distance_different():
 
     assert sa.numpy() != 0
 
+
 def test_spectral_distance_zero_input():
-    y_true = [[0., 0., 0.]]
+    y_true = [[0.0, 0.0, 0.0]]
     y_true_tensor = tf.convert_to_tensor(y_true)
     y_pred_tensor = tf.convert_to_tensor(y_true)
 
     sa = masked_spectral_distance(y_true_tensor, y_pred_tensor)
     logger.info("Spectral Angle for zero input vectors: {}".format(sa.numpy()))
+
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,43 @@ def test_prosit_retention_time_model():
 
 def test_prosit_intensity_model():
     model = PrositIntensityPredictor()
+    seq_len = model.seq_length
+    model.build(
+        {
+            "sequence": (None, seq_len,),
+            "collision_energy": (None, 1),
+            "precursor_charge": (None, 6),
+        }
+    )
+    model.summary(print_fn=logger.info)
+    logger.info(model)
+    assert model is not None
+    assert model.ptm_encoder is None
+    assert model.ptm_aa_fusion is None
+
+def test_prosit_intensity_model_ptm_on():
+    model = PrositIntensityPredictor(use_ptm_counts=True)
+    logger.info(model.input_keys)
+    logger.info(model)
+    assert model is not None
+    assert model.ptm_encoder is not None
+    assert model.ptm_aa_fusion is not None
+
+def test_prosit_intensity_model_ptm_on_input():
+    model = PrositIntensityPredictor(use_ptm_counts=True)
+    seq_len = model.seq_length
+    model.build(
+        {
+            "sequence": (None, seq_len,),
+            "collision_energy": (None, 1),
+            "precursor_charge": (None, 6),
+            "fragmentation_type": (None, 1),
+            "ptm_atom_count_loss": (None, seq_len, 6,),
+            "ptm_atom_count_gain": (None, seq_len, 6,),
+        }
+    )
+    model.summary(print_fn=logger.info)
+    logger.info(model.input_keys)
     logger.info(model)
     assert model is not None
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,8 @@
-
 from dlomix.models import PrositRetentionTimePredictor, PrositIntensityPredictor
 import logging
+import pytest
 
 logger = logging.getLogger(__name__)
-
 
 
 def test_prosit_retention_time_model():
@@ -11,12 +10,16 @@ def test_prosit_retention_time_model():
     logger.info(model)
     assert model is not None
 
+
 def test_prosit_intensity_model():
     model = PrositIntensityPredictor()
     seq_len = model.seq_length
     model.build(
         {
-            "sequence": (None, seq_len,),
+            "sequence": (
+                None,
+                seq_len,
+            ),
             "collision_energy": (None, 1),
             "precursor_charge": (None, 6),
         }
@@ -27,6 +30,7 @@ def test_prosit_intensity_model():
     assert model.ptm_encoder is None
     assert model.ptm_aa_fusion is None
 
+
 def test_prosit_intensity_model_ptm_on():
     model = PrositIntensityPredictor(use_ptm_counts=True)
     logger.info(model.input_keys)
@@ -35,17 +39,34 @@ def test_prosit_intensity_model_ptm_on():
     assert model.ptm_encoder is not None
     assert model.ptm_aa_fusion is not None
 
+
 def test_prosit_intensity_model_ptm_on_input():
     model = PrositIntensityPredictor(use_ptm_counts=True)
     seq_len = model.seq_length
     model.build(
         {
-            "sequence": (None, seq_len,),
+            "sequence": (
+                None,
+                seq_len,
+            ),
             "collision_energy": (None, 1),
             "precursor_charge": (None, 6),
             "fragmentation_type": (None, 1),
-            "ptm_atom_count_loss": (None, seq_len, 6,),
-            "ptm_atom_count_gain": (None, seq_len, 6,),
+            "ptm_atom_count_loss": (
+                None,
+                seq_len,
+                6,
+            ),
+            "ptm_atom_count_gain": (
+                None,
+                seq_len,
+                6,
+            ),
+            "ptm_location": (
+                None,
+                seq_len,
+                1,
+            ),
         }
     )
     model.summary(print_fn=logger.info)
@@ -54,4 +75,35 @@ def test_prosit_intensity_model_ptm_on_input():
     assert model is not None
 
 
+def test_prosit_intensity_model_ptm_on_missing():
+    model = PrositIntensityPredictor(use_ptm_counts=True)
+    seq_len = model.seq_length
+    with pytest.raises(ValueError):
+        model.build(
+            {
+                "sequence": (
+                    None,
+                    seq_len,
+                ),
+                "collision_energy": (None, 1),
+                "precursor_charge": (None, 6),
+                "fragmentation_type": (None, 1),
+                # no PTM features
+            }
+        )
 
+
+def test_prosit_intensity_model_encoding_metadata_missing():
+    model = PrositIntensityPredictor()
+    seq_len = model.seq_length
+
+    with pytest.raises(ValueError):
+        model.build(
+            {
+                "sequence": (
+                    None,
+                    seq_len,
+                ),
+                # no meta-data while expected
+            }
+        )


### PR DESCRIPTION
## Changes:
- updated prosit intensity model to use ptm count features when proper input arguments are passed and boolean flag is used, otherwise the layers are not created and the forward pass excludes them (original flow is the same)
- meta data keys are checked against a pre-defined list and concatenated as one input
- count features are done in the same way


## Notes:
- we can consider later passing the flags for ptms and features in the kwargs argument, but it has the disadvantage that the layers are created in all cases; the current implementation does not create the layers based on the constructor call
- alignment with the dataset class on the keys of the input is still open
- when an expected behavior is encountered, an ValueError is raised (e.g. PTM mode on while keys do not exist in the input, metadata are expected and not supplied, etc..)