### PR TITLE
Feature/flag for termini addition and additional hf data sources

### DIFF
--- a/src/dlomix/__init__.py
+++ b/src/dlomix/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.1.1dev0"
 
 META_DATA = {
     "author": "Omar Shouman",

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -26,6 +26,7 @@ class ChargeStateDataset(PeptideDataset):
         pad (bool): Whether to pad the sequences to the maximum length. Default is True.
         padding_value (int): The value to use for padding. Default is 0.
         alphabet (Dict): The mapping of characters to integers for encoding the sequences. Default is ALPHABET_UNMOD.
+        with_termini (bool): Whether to add the N- and C-termini in the sequence column, even if they do not exist. Defaults to True.
         encoding_scheme (Union[str, EncodingScheme]): The encoding scheme to use for encoding the sequences. Default is EncodingScheme.UNMOD.
         processed (bool): Whether the data has been preprocessed. Default is False.
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cahce()` on the generate TF Datasets).
@@ -50,6 +51,7 @@ class ChargeStateDataset(PeptideDataset):
         pad: bool = True,
         padding_value: int = 0,
         alphabet: Dict = ALPHABET_UNMOD,
+        with_termini: bool = True,
         encoding_scheme: Union[str, EncodingScheme] = EncodingScheme.UNMOD,
         processed: bool = False,
         enable_tf_dataset_cache: bool = False,
@@ -75,6 +77,7 @@ class ChargeStateDataset(PeptideDataset):
             pad,
             padding_value,
             alphabet,
+            with_termini,
             encoding_scheme,
             processed,
             enable_tf_dataset_cache,

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -26,6 +26,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         pad (bool): Whether to pad the sequences to the maximum length.
         padding_value (int): The value to use for padding.
         alphabet (Dict): The mapping of characters to integers for encoding the sequences.
+        with_termini (bool): Whether to add the N- and C-termini in the sequence column, even if they do not exist. Defaults to True.
         encoding_scheme (Union[str, EncodingScheme]): The encoding scheme to use for encoding the sequences.
         processed (bool): Whether the data has been preprocessed before or not.
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cahce()` on the generate TF Datasets).
@@ -51,6 +52,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         pad: bool = True,
         padding_value: int = 0,
         alphabet: Dict = ALPHABET_UNMOD,
+        with_termini: bool = True,
         encoding_scheme: Union[str, EncodingScheme] = EncodingScheme.UNMOD,
         processed: bool = False,
         enable_tf_dataset_cache: bool = False,
@@ -76,6 +78,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
             pad,
             padding_value,
             alphabet,
+            with_termini,
             encoding_scheme,
             processed,
             enable_tf_dataset_cache,

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -26,6 +26,7 @@ class RetentionTimeDataset(PeptideDataset):
         pad (bool): Whether to pad sequences to the maximum length. Defaults to True.
         padding_value (int): The value to use for padding sequences. Defaults to 0.
         alphabet (Dict): The alphabet used for encoding sequences. Defaults to ALPHABET_UNMOD.
+        with_termini (bool): Whether to add the N- and C-termini in the sequence column, even if they do not exist. Defaults to True.
         encoding_scheme (Union[str, EncodingScheme]): The encoding scheme to use for sequences. Defaults to EncodingScheme.UNMOD.
         processed (bool): Whether the dataset has been preprocessed. Defaults to False.
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cahce()` on the generate TF Datasets).
@@ -50,6 +51,7 @@ class RetentionTimeDataset(PeptideDataset):
         pad: bool = True,
         padding_value: int = 0,
         alphabet: Dict = ALPHABET_UNMOD,
+        with_termini: bool = True,
         encoding_scheme: Union[str, EncodingScheme] = EncodingScheme.UNMOD,
         processed: bool = False,
         enable_tf_dataset_cache: bool = False,
@@ -75,6 +77,7 @@ class RetentionTimeDataset(PeptideDataset):
             pad,
             padding_value,
             alphabet,
+            with_termini,
             encoding_scheme,
             processed,
             enable_tf_dataset_cache,


### PR DESCRIPTION
# Changes:
- added `with_termini`flag to datasets, where the behavior of adding []- and -[] can be controlled,  even if the peptide sequence does not have any n-terminal and c-terminal mods.
- added experimental feature to load data from in-memory hf Dataset and DatasetDict objects, `data_format="hf"`
- added experimental feature to load data directly from the hub given its path on the Hugging Face Hub, `data_format="hub"`
- added tests in `test_datasets.py`