### PR TITLE
Fix/nested sequence structures in model features

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -4,18 +4,15 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Build"]
-    types:
-      - completed
-    branches:
-      - main
+    types: [completed]
+    branches: [main]
 
 jobs:
   release:
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.ref == 'refs/heads/main'
+      github.event.workflow_run.head_branch == 'main'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ pip install dlomix[wandb]
 - Fragment Ion Intensity Prediction:
     - a multi-output regression problem where the intensity values for fragment ions are predicted given a peptide sequence along with some additional features.
 
-- Peptide Detectability:
+- Peptide Detectability (Pfly) [4]:
     - a multi-class classification problem where the detectability of a peptide is predicted given the peptide sequence.
 
 
@@ -97,3 +97,7 @@ Robbin Bouwmeester, Ralf Gabriels, Niels Hulstaert, Lennart Martens, Sven Degroe
 bioRxiv 2020.03.28.013003; doi: 10.1101/2020.03.28.013003
 
 [3] Bouwmeester, R., Gabriels, R., Hulstaert, N. et al. DeepLC can predict retention times for peptides that carry as-yet unseen modifications. Nat Methods 18, 1363–1369 (2021). https://doi.org/10.1038/s41592-021-01301-5
+
+[**Detectability - Pfly**]
+
+[4] Abdul-Khalek, N., Picciani, M., Wimmer, R., Overgaard, M. T., Wilhelm, M., & Gregersen Echers, S. (2024). To fly, or not to fly, that is the question: A deep learning model for peptide detectability prediction in mass spectrometry. bioRxiv, 2024-10.


### PR DESCRIPTION
## Changes:
- Fix to handle casting of nested data structures in PeptideDataset
- Fix to always assume no splitting when a hugging face remote or in-memory dataset is provided
- minor additions in README.md and fixes in GitHub Actions workflow