### PR TITLE
Feature/expand docs for multibackend

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
   jobs:
@@ -16,7 +16,14 @@ build:
     # M Modules first, E no headers, f force overwrite, l links, o output directory
       - sphinx-apidoc -M -E -f -l -o docs/ src/dlomix/
       - python docs/codify_package_titles.py
-
+    build:
+      html:
+        - make build-docs
+        - echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > docs/_build/html/index.html
+      pdf:
+        - echo "Skipping PDF build"
+      epub:
+        - echo "Skipping EPUB build"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,9 +25,11 @@ build:
         - mkdir -p $READTHEDOCS_OUTPUT/html/pytorch
         - ls -l docs/_build/html/pytorch/
         - cp -r docs/_build/html/pytorch/* $READTHEDOCS_OUTPUT/html/pytorch/
-        - sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $READTHEDOCS_OUTPUT/html/index.html'
+        - chmod +x docs/create_root_index_redirect.sh
+        - bash docs/create_root_index_redirect.sh $READTHEDOCS_OUTPUT/html
         - ls -l $READTHEDOCS_OUTPUT/html/
         - cat $READTHEDOCS_OUTPUT/html/index.html
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -25,8 +25,7 @@ build:
         - mkdir -p $READTHEDOCS_OUTPUT/html/pytorch
         - ls -l docs/_build/html/pytorch/
         - cp -r docs/_build/html/pytorch/* $READTHEDOCS_OUTPUT/html/pytorch/
-        - REDIRECT_HTML='<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>'
-        - echo "$REDIRECT_HTML" > $READTHEDOCS_OUTPUT/html/index.html
+        - sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $READTHEDOCS_OUTPUT/html/index.html'
         - ls -l $READTHEDOCS_OUTPUT/html/
         - cat $READTHEDOCS_OUTPUT/html/index.html
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,10 +20,6 @@ build:
       html:
         - make build-docs
         - echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > docs/_build/html/index.html
-      pdf:
-        - echo "Skipping PDF build"
-      epub:
-        - echo "Skipping EPUB build"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,6 +19,12 @@ build:
     build:
       html:
         - make build-docs
+        - mkdir -p $READTHEDOCS_OUTPUT/html/tensorflow
+        - cp -r docs/_build/html/tensorflow/* $READTHEDOCS_OUTPUT/html/tensorflow/
+        - mkdir -p $READTHEDOCS_OUTPUT/html/pytorch
+        - cp -r docs/_build/html/pytorch/* $READTHEDOCS_OUTPUT/html/pytorch/
+        - sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $READTHEDOCS_OUTPUT/html/index.html'
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,10 +20,15 @@ build:
       html:
         - make build-docs
         - mkdir -p $READTHEDOCS_OUTPUT/html/tensorflow
+        - ls -l docs/_build/html/tensorflow/
         - cp -r docs/_build/html/tensorflow/* $READTHEDOCS_OUTPUT/html/tensorflow/
         - mkdir -p $READTHEDOCS_OUTPUT/html/pytorch
+        - ls -l docs/_build/html/pytorch/
         - cp -r docs/_build/html/pytorch/* $READTHEDOCS_OUTPUT/html/pytorch/
-        - sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $READTHEDOCS_OUTPUT/html/index.html'
+        - REDIRECT_HTML='<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>'
+        - echo "$REDIRECT_HTML" > $READTHEDOCS_OUTPUT/html/index.html
+        - ls -l $READTHEDOCS_OUTPUT/html/
+        - cat $READTHEDOCS_OUTPUT/html/index.html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,8 +19,6 @@ build:
     build:
       html:
         - make build-docs
-        - echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > docs/_build/html/index.html
-
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,10 +20,8 @@ build:
       html:
         - make build-docs
         - mkdir -p $READTHEDOCS_OUTPUT/html/tensorflow
-        - ls -l docs/_build/html/tensorflow/
-        - cp -r docs/_build/html/tensorflow/* $READTHEDOCS_OUTPUT/html/tensorflow/
         - mkdir -p $READTHEDOCS_OUTPUT/html/pytorch
-        - ls -l docs/_build/html/pytorch/
+        - cp -r docs/_build/html/tensorflow/* $READTHEDOCS_OUTPUT/html/tensorflow/
         - cp -r docs/_build/html/pytorch/* $READTHEDOCS_OUTPUT/html/pytorch/
         - chmod +x docs/create_root_index_redirect.sh
         - bash docs/create_root_index_redirect.sh $READTHEDOCS_OUTPUT/html

--- a/Makefile
+++ b/Makefile
@@ -44,17 +44,31 @@ lint-errors-only:
 
 BACKEND ?= tensorflow
 DOCS_DIR := docs
-BUILD_DIR := $(DOCS_DIR)/_build/html/$(BACKEND)
+BUILD_ROOT := $(DOCS_DIR)/_build
+BUILD_DIR := $(BUILD_ROOT)/html/$(BACKEND)
 
 build-docs-framework:
 	sphinx-apidoc -M -f -E -l -o $(DOCS_DIR)/ src/dlomix/
 	python $(DOCS_DIR)/codify_package_titles.py
 	DLOMIX_BACKEND=$(BACKEND) sphinx-build -b html $(DOCS_DIR)/ $(BUILD_DIR)
-	open $(BUILD_DIR)/index.html
 
 build-docs:
+	# Clean old builds
+	rm -rf $(BUILD_ROOT)/html
+
+	# Build TensorFlow
 	$(MAKE) build-docs-framework BACKEND=tensorflow
+
+	# Build PyTorch
 	$(MAKE) build-docs-framework BACKEND=pytorch
+
+	$(MAKE) create-root-index
+
+	# Optional: open main page
+	open $(BUILD_ROOT)/html/index.html
+
+create-root-index:
+	echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > $(BUILD_ROOT)/html/index.html
 
 
 all: install format test

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,21 @@ lint:
 lint-errors-only:
 	pylint --errors-only --disable=R,C ./src/dlomix/*
 
+# Documentation
+
+BACKEND ?= tensorflow
+DOCS_DIR := docs
+BUILD_DIR := $(DOCS_DIR)/_build/html/$(BACKEND)
+
+build-docs-framework:
+	sphinx-apidoc -M -f -E -l -o $(DOCS_DIR)/ src/dlomix/
+	python $(DOCS_DIR)/codify_package_titles.py
+	DLOMIX_BACKEND=$(BACKEND) sphinx-build -b html $(DOCS_DIR)/ $(BUILD_DIR)
+	open $(BUILD_DIR)/index.html
+
 build-docs:
-	sphinx-apidoc -M -f -E -l -o docs/ src/dlomix/
-	python docs/codify_package_titles.py
-	cd docs && make clean html
-	cd docs/_build/html/ && open index.html
+	$(MAKE) build-docs-framework BACKEND=tensorflow
+	$(MAKE) build-docs-framework BACKEND=pytorch
+
 
 all: install format test

--- a/Makefile
+++ b/Makefile
@@ -62,11 +62,5 @@ build-docs:
 	# Build PyTorch
 	$(MAKE) build-docs-framework BACKEND=pytorch
 
-	$(MAKE) create-root-index
-
-create-root-index:
-	sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $(BUILD_ROOT)/html/index.html'
-
-
 
 all: install format test

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ build-docs:
 	$(MAKE) create-root-index
 
 create-root-index:
-	echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > $(BUILD_ROOT)/html/index.html
+	sh -c 'echo "<html><head><meta http-equiv=\"refresh\" content=\"0; url=tensorflow/index.html\"></head></html>" > $(BUILD_ROOT)/html/index.html'
+
 
 
 all: install format test

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,18 @@ build-docs:
 	# Build PyTorch
 	$(MAKE) build-docs-framework BACKEND=pytorch
 
+build-docs-local:
+	# Clean old builds
+	rm -rf $(BUILD_ROOT)/html
+
+	# Build TensorFlow
+	$(MAKE) build-docs-framework BACKEND=tensorflow
+
+	# Build PyTorch
+	$(MAKE) build-docs-framework BACKEND=pytorch
+
+	bash $(DOCS_DIR)/create_root_index_redirect.sh $(BUILD_ROOT)/html
+	open $(BUILD_ROOT)/html/index.html
+
 
 all: install format test

--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,6 @@ build-docs:
 
 	$(MAKE) create-root-index
 
-	# Optional: open main page
-	open $(BUILD_ROOT)/html/index.html
-
 create-root-index:
 	echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > $(BUILD_ROOT)/html/index.html
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,80 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <style>
+    #backend-switch {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 1000;
+      background: rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(8px);
+      color: #eee;
+      padding: 0.4rem 0.75rem;
+      border-radius: 0.5rem;
+      font-size: 0.9rem;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    }
+
+    #backend-switch a {
+      color: #4eaaff;
+      text-decoration: none;
+      margin-left: 0.5rem;
+    }
+
+    #backend-switch a:hover {
+      text-decoration: underline;
+    }
+  </style>
+{% endblock %}
+
+{% block footer %}
+  <div id="backend-switch">
+  {% if backend == "pytorch" %} <a href="#" onclick="switchBackend('tensorflow'); return false;">TensorFlow</a> | PyTorch
+  {% else %} TensorFlow |<a href="#" onclick="switchBackend('pytorch'); return false;">PyTorch</a>
+  {% endif %}
+</div>
+
+
+
+  <script>
+  function switchBackend(targetBackend) {
+    const currentURL = window.location.href;
+    const backendMatch = currentURL.match(/(pytorch|tensorflow)/);
+
+    if (!backendMatch) {
+      // Fallback if backend not found
+      window.location.href = targetBackend + "/index.html";
+      return;
+    }
+
+    const currentBackend = backendMatch[1];
+    const newURL = currentURL.replace(currentBackend, targetBackend);
+
+    // If running from local file system, skip fetch check
+    if (window.location.protocol === "file:") {
+      window.location.href = newURL;
+      return;
+    }
+
+    // Hosted: test if page exists before redirecting
+    fetch(newURL, { method: 'HEAD' })
+      .then(res => {
+        if (res.ok) {
+          window.location.href = newURL;
+        } else {
+          const baseURL = currentURL.split(currentBackend)[0];
+          window.location.href = baseURL + targetBackend + "/index.html";
+        }
+      })
+      .catch(() => {
+        const baseURL = currentURL.split(currentBackend)[0];
+        window.location.href = baseURL + targetBackend + "/index.html";
+      });
+  }
+</script>
+
+
+  {{ super() }}
+{% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -31,10 +31,10 @@
 
 {% block footer %}
   <div id="backend-switch">
-  {% if backend == "pytorch" %} <a href="#" onclick="switchBackend('tensorflow'); return false;">TensorFlow</a> | PyTorch
-  {% else %} TensorFlow |<a href="#" onclick="switchBackend('pytorch'); return false;">PyTorch</a>
-  {% endif %}
-</div>
+{% if backend == "pytorch" %} <a href="#" onclick="switchBackend('tensorflow'); return false;">TensorFlow</a> | PyTorch
+{% else %} TensorFlow |<a href="#" onclick="switchBackend('pytorch'); return false;">PyTorch</a>
+{% endif %}
+  </div>
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,24 @@ author = __author__
 release = __version__
 
 
+# -- Backend configuration ---------------------------------------------------
+
+from src.dlomix.config import (
+    _BACKEND,
+    BACKEND_PRETTY_NAME,
+    PYTORCH_BACKEND,
+    TENSORFLOW_BACKEND,
+)
+
+# Add to context for use in templates
+html_context = {
+    "backend": _BACKEND,
+    "other_backend": PYTORCH_BACKEND[0]
+    if _BACKEND in TENSORFLOW_BACKEND
+    else TENSORFLOW_BACKEND[0],
+    "backend_label": BACKEND_PRETTY_NAME,
+}
+
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/create_root_index_redirect.sh
+++ b/docs/create_root_index_redirect.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+OUTPUT_DIR="$1"
+
+mkdir -p "$OUTPUT_DIR"
+echo '<html><head><meta http-equiv="refresh" content="0; url=tensorflow/index.html"></head></html>' > "$OUTPUT_DIR/index.html"

--- a/docs/dlomix.data.rst
+++ b/docs/dlomix.data.rst
@@ -42,7 +42,19 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: dlomix.data.detectability
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.data.fragment_ion_intensity
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.data.ion_mobility
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/dlomix.eval.rst
+++ b/docs/dlomix.eval.rst
@@ -10,7 +10,25 @@ Submodules
 ----------
 
 
+.. automodule:: dlomix.eval.chargestate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.eval.chargestate_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.eval.rt_eval
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.eval.rt_eval_torch
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/dlomix.layers.rst
+++ b/docs/dlomix.layers.rst
@@ -14,3 +14,21 @@ Submodules
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+.. automodule:: dlomix.layers.attention_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.layers.bi_gru_seq_encoder_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.layers.gru_seq_decoder_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/dlomix.losses.rst
+++ b/docs/dlomix.losses.rst
@@ -14,3 +14,15 @@ Submodules
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+.. automodule:: dlomix.losses.intensity_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.losses.ionmob_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/dlomix.models.rst
+++ b/docs/dlomix.models.rst
@@ -16,13 +16,49 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: dlomix.models.chargestate
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.models.chargestate_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.models.deepLC
    :members:
    :undoc-members:
    :show-inheritance:
 
 
+.. automodule:: dlomix.models.detectability
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.models.detectability_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.models.ionmob_torch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.models.prosit
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.models.prosit_torch
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/dlomix.reports.rst
+++ b/docs/dlomix.reports.rst
@@ -10,6 +10,12 @@ Submodules
 ----------
 
 
+.. automodule:: dlomix.reports.DetectabilityReport
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.reports.IntensityReport
    :members:
    :undoc-members:

--- a/docs/dlomix.rst
+++ b/docs/dlomix.rst
@@ -24,7 +24,25 @@ Submodules
 ----------
 
 
+.. automodule:: dlomix.config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.detectability_model_constants
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.types
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,11 +33,13 @@ The goal of DLOmix is to be easy to use and flexible, while still providing the 
 
 .. toctree::
    :glob:
-   :reversed:
    :maxdepth: 2
    :caption: How To
 
-   notes/*
+   notes/quickstart
+   notes/installation
+   notes/backend_usage
+   notes/citation
 
 
 .. toctree::

--- a/docs/notes/backend_usage.rst
+++ b/docs/notes/backend_usage.rst
@@ -17,13 +17,14 @@ When importing classes from DLOmix, you should always use the top-level module:
    # The backend implementation (TensorFlow or PyTorch) will be selected automatically
    # based on your configuration
 
-The class names in your code will always be the same (e.g., `ChargeStatePredictor`, `AttentionLayer`), regardless of which backend is being used. DLOmix handles the backend selection automatically.
+The class names in your code will always be the same (e.g., :code:`ChargeStatePredictor`, :code:`AttentionLayer`), regardless of which backend is being used. DLOmix handles the backend selection automatically.
 
 If you are interested in the implementation details, you can find them under the respective modules with the following naming convention:
-- src/dlomix/MODULE_NAME/SUBMODULE.py (for TensorFlow, always with no suffix)
-- src/dlomix/MODULE_NAME/SUBMODULE_torch.py (for PyTorch, always with a `_torch` suffix)
 
-Note that some modules are shared across both backends, hence they do not have any files with `_torch` suffix.
+- :code:`src/dlomix/{SUBPACKAGE_NAME}/{MODULE_NAME}.py` (for TensorFlow, always with no suffix)
+- :code:`src/dlomix/{SUBPACKAGE_NAME}/{MODULE_NAME}_torch.py` (for PyTorch, always with a :code:`_torch` suffix)
+
+Note that some modules are shared across both backends, hence they do not have any files with :code:`_torch` suffix.
 
 
 How Backend Selection Works

--- a/docs/notes/backend_usage.rst
+++ b/docs/notes/backend_usage.rst
@@ -1,0 +1,35 @@
+Backend Usage Guide
+*******************
+
+DLOmix provides a unified API that works with both TensorFlow and PyTorch backends. This guide explains how the import system works and how to use the correct classes in your code.
+
+Importing Classes
+*******************
+
+When importing classes from DLOmix, you should always use the top-level module:
+
+.. code-block:: python
+
+   # Correct way to import
+   from dlomix.models import ChargeStatePredictor
+   from dlomix.layers import AttentionLayer
+
+   # The backend implementation (TensorFlow or PyTorch) will be selected automatically
+   # based on your configuration
+
+The class names in your code will always be the same (e.g., `ChargeStatePredictor`, `AttentionLayer`), regardless of which backend is being used. DLOmix handles the backend selection automatically.
+
+How Backend Selection Works
+****************************
+
+1. **Automatic Detection**: DLOmix automatically detects which backends are available in your environment.
+
+2. **Default Selection**: If both TensorFlow and PyTorch are installed, TensorFlow will be used by default.
+
+3. **Environment Variables**: You can set the backend via environment variables:
+
+   .. code-block:: bash
+
+      export DLOMIX_BACKEND=pytorch
+
+   This must be set before importing DLOmix.

--- a/docs/notes/backend_usage.rst
+++ b/docs/notes/backend_usage.rst
@@ -19,6 +19,13 @@ When importing classes from DLOmix, you should always use the top-level module:
 
 The class names in your code will always be the same (e.g., `ChargeStatePredictor`, `AttentionLayer`), regardless of which backend is being used. DLOmix handles the backend selection automatically.
 
+If you are interested in the implementation details, you can find them under the respective modules with the following naming convention:
+- src/dlomix/MODULE_NAME/SUBMODULE.py (for TensorFlow, always with no suffix)
+- src/dlomix/MODULE_NAME/SUBMODULE_torch.py (for PyTorch, always with a `_torch` suffix)
+
+Note that some modules are shared across both backends, hence they do not have any files with `_torch` suffix.
+
+
 How Backend Selection Works
 ****************************
 
@@ -30,6 +37,8 @@ How Backend Selection Works
 
    .. code-block:: bash
 
+      export DLOMIX_BACKEND=tensorflow # default behavior if env variable is not set
       export DLOMIX_BACKEND=pytorch
 
-   This must be set before importing DLOmix.
+
+   This must be set before importing DLOmix or any of its modules in the user code.

--- a/docs/notes/citation.rst
+++ b/docs/notes/citation.rst
@@ -1,4 +1,4 @@
 Citation
-========
+*********
 
 DLOmix is in its early stages of development. Stay tuned for a publication.

--- a/docs/notes/installation.rst
+++ b/docs/notes/installation.rst
@@ -28,7 +28,7 @@ DLOmix supports multiple deep learning backends. To use TensorFlow/Keras or PyTo
 
    While DLOmix supports both TensorFlow and PyTorch backends, you only need to install the backend you intend to use. The library will use the available backend automatically. If both backends are installed, TensorFlow will be used by default unless explicitly configured.
 
-.. include:: ./notes/backend_usage.rst
+.. include:: backend_usage.rst
 
 
 Development Installation

--- a/docs/notes/installation.rst
+++ b/docs/notes/installation.rst
@@ -1,5 +1,3 @@
-
-
 Installation
 ************
 
@@ -9,21 +7,32 @@ Installation
   DLOmix is in its early stages, current release is a pre-release version.
   Changes to the API are highly probable. If you have feedback, ideas for improvements, or if you find a bug, please open an issue on GitHub.
 
-DLOmix can be installed via pip, this install the package and the main dependencies only, excluding the backend framework to be used (TensorFlow/Keras or PyTorch).:
+DLOmix can be installed via pip, this installs the package and the main dependencies only, excluding the backend framework to be used (TensorFlow/Keras or PyTorch):
 
 .. code-block:: bash
 
   pip install dlomix
 
-To use TensorFlow/Keras or PyTorch as a backend together with DLOmix, use the respective command:
+Backend Selection
+******************
+
+DLOmix supports multiple deep learning backends. To use TensorFlow/Keras or PyTorch as a backend together with DLOmix, install with the respective command:
+
 .. code-block:: bash
 
   pip install dlomix[tensorflow]  # shorter alternatives: [tf]
+
   pip install dlomix[pytorch]  # shorter alternatives: [torch], [pt]
 
-.. code-block:: bash
+.. note::
 
-  pip install dlomix
+   While DLOmix supports both TensorFlow and PyTorch backends, you only need to install the backend you intend to use. The library will use the available backend automatically. If both backends are installed, TensorFlow will be used by default unless explicitly configured.
+
+.. include:: ./notes/backend_usage.rst
+
+
+Development Installation
+************************
 
 To get the develop version, you can install directly from GitHub (develop branch):
 
@@ -31,8 +40,17 @@ To get the develop version, you can install directly from GitHub (develop branch
 
   pip install git+https://github.com/wilhelm-lab/dlomix.git@develop
 
+Optional Dependencies
+*********************
+
 If you decide to use Weights & Biases for reporting, you can use the extra install command:
 
 .. code-block:: bash
 
   pip install dlomix[wandb]
+
+For development purposes, you can install all dependencies including both backends:
+
+.. code-block:: bash
+
+  pip install dlomix[dev]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx==6.1.3
 readthedocs-sphinx-search==0.3.2
 sphinx-book-theme==1.0.1
 .[wandb] # install from the current dlomix codebase and not from PyPI + wandb
-.[tf] # default backend tensorflow
+.[tensorflow,pytorch] # install both backends for documentation


### PR DESCRIPTION
## Changes:

- extend the documentation to support both TensorFlow and PyTorch backends
- added backend usage documentation with import guides and configuration instructions
- generation of docs is done by overriding the default build behavior of readthedocs (under build in `readthedocs.yaml`), building docs once for each backend (using a `make` recipe), then adding a default entry index.html redirect to TensorFlow as default (using a bash script triggered at the end of the build)

