### PR TITLE
updated default pretrained model path and fixed argument names with t…

### DIFF
--- a/notebooks/Example_Detectability_Model_Walkthrough_prediction_colab.ipynb
+++ b/notebooks/Example_Detectability_Model_Walkthrough_prediction_colab.ipynb
@@ -124,7 +124,7 @@
     "input_dimension = len(alphabet)\n",
     "num_cells = 64\n",
     "\n",
-    "model = DetectabilityModel(num_units = num_cells, num_clases = total_num_classes)"
+    "model = DetectabilityModel(num_units=num_cells, num_classes=total_num_classes)"
    ]
   },
   {
@@ -135,9 +135,38 @@
     "\n",
     "In the following section, you need to specify the path to the model weights you wish to use. The default path provided is set to the weights for the **Pfly** model, which is the fine-tuned model mentioned in the publication associated with this notebook.\n",
     "\n",
-    "- **Using the Default Pfly Model**: If you are utilizing the fine-tuned Pfly model as described in the publication, you can keep the default path unchanged. This will load the model weights for Pfly.\n",
+    "- **Using the Default Pfly Model**: If you are utilizing the fine-tuned Pfly model as described in the publication, you can keep the default path unchanged. This will load the model weights for Pfly. The model weights are stored in the pretrained models folder in the dlomix repository.\n",
     "\n",
-    "- **Using the Base Model or Different Weights**: If you intend to use the base model or have different weights (e.g., for a custom model), you should update the path to reflect the location of these weights."
+    "- **Using the Base Model or Different Weights**: If you intend to use the base model or have different weights (e.g., for a custom model), you **should update the path to reflect the location of these weights**.\n",
+    "\n",
+    "**Notes:**\n",
+    "1. We always assume that the weights are stored under the given path using either `save_weights()` or a `ModelCheckpoint` callback with the parameter `save_weights_only=True`.\n",
+    "2. Make sure to provide the fullpath to the checkpoint and not only the parent folder name, otherwise you might get issues with loading the model.\n",
+    "3. If you have the dlomix repository cloned already, you can use `'../pretrained_models/original_detectability_fine_tuned_model_FINAL/original_detectability_fine_tuned_model_FINAL'` as the file path. Else, the code below will download the weights to a local folder in the current working directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "import os\n",
+    "import json\n",
+    "\n",
+    "model_name = \"original_detectability_fine_tuned_model_FINAL\"\n",
+    "api_url = f\"https://api.github.com/repos/wilhelm-lab/dlomix/contents/pretrained_models/{model_name}\"\n",
+    "local_download_folder = \"pretrained_detectability_model\"\n",
+    "\n",
+    "os.makedirs(local_download_folder, exist_ok=True)\n",
+    "\n",
+    "files = json.loads(urllib.request.urlopen(api_url).read())\n",
+    "for f in files:\n",
+    "    if f['type'] == 'file':\n",
+    "        urllib.request.urlretrieve(f['download_url'], os.path.join(local_download_folder, f['name']))\n",
+    "        \n",
+    "print(f\"Downloaded {len([f for f in files if f['type'] == 'file'])} files to {local_download_folder}/\")"
    ]
   },
   {
@@ -148,9 +177,13 @@
    "source": [
     "## Loading model weights \n",
     "\n",
-    "model_save_path = 'output/weights/new_fine_tuned_model/fine_tuned_model_weights_detectability'\n",
+    "# use this if you have the repository cloned \n",
+    "# model_full_path = '../pretrained_models/original_detectability_fine_tuned_model_FINAL/original_detectability_fine_tuned_model_FINAL'\n",
     "\n",
-    "model.load_weights(model_save_path)"
+    "# use this if you downloaded the model via the script in the previous cell\n",
+    "model_full_path = f\"{local_download_folder}/{model_name}\"\n",
+    "\n",
+    "model.load_weights(model_full_path)"
    ]
   },
   {
@@ -328,6 +361,15 @@
    "metadata": {},
    "source": [
     "To generate reports and calculate evaluation metrics against predictions, we obtain the targets and the data for the specific dataset split. This can be achieved using the `DetectabilityDataset` class directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.unique(np.argmax(predictions, axis=1), return_counts=True)"
    ]
   },
   {

--- a/notebooks/Example_Detectability_Model_Walkthrough_training_and_fine_tuning.ipynb
+++ b/notebooks/Example_Detectability_Model_Walkthrough_training_and_fine_tuning.ipynb
@@ -225,7 +225,7 @@
     "input_dimension = len(alphabet)\n",
     "num_cells = 64\n",
     "\n",
-    "model = DetectabilityModel(num_units = num_cells, num_clases = total_num_classes)"
+    "model = DetectabilityModel(num_units=num_cells, num_classes=total_num_classes)"
    ]
   },
   {
@@ -775,8 +775,8 @@
     "# define again if not in environment from training run\n",
     "load_model_path = model_save_path #'output/weights/new_base_model/base_model_weights_detectability'\n",
     "\n",
-    "fine_tuned_model = DetectabilityModel(num_units = num_cells,  \n",
-    "                                      num_clases = total_num_classes)\n",
+    "fine_tuned_model = DetectabilityModel(num_units=num_cells,  \n",
+    "                                      num_classes=total_num_classes)\n",
     "\n",
     "fine_tuned_model.load_weights(load_model_path)"
    ]
@@ -858,7 +858,10 @@
    "source": [
     "## Loading best model weights \n",
     "\n",
-    "model_save_path_FT = 'output/weights/new_fine_tuned_model/fine_tuned_model_weights_detectability'\n",
+    "# uncomment to define again if the run was interrupted and you want to load the best model weights from the previous finetuning\n",
+    "# else, it should still be in the environment\n",
+    "\n",
+    "#model_save_path_FT = 'output/weights/new_fine_tuned_model/fine_tuned_model_weights_detectability'\n",
     "\n",
     "fine_tuned_model.load_weights(model_save_path_FT)"
    ]


### PR DESCRIPTION
## Changes:

- added the correct reference to the fine-tuned model in the inference detectability notebook
- included a scirpt that downloads it in case the user did not clone the whole repo and just pip installed dlomix
- added some text to highlight this behavior within the notebook
- minor fix in the argument name `num_classes` since it had a typo that was fixed in the model definition, but not in the notebook.


