### PR TITLE
version 0.2.6 - fixes for alphabet learning and streamlined default behavior for number of processes for hf datasets processing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,22 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.1
+    rev: v2.3.3
     hooks:
     -   id: autoflake
         args: [--remove-all-unused-imports, --ignore-init-module-imports, --in-place]
         exclude: src/dlomix/_register_keras.py
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 8.0.1
     hooks:
     -   id: isort
         name: isort (python)
         args: ["--profile",  "black"]
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 26.3.1
     hooks:
     -   id: black

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,6 +3,26 @@
 {% block extrahead %}
   {{ super() }}
   <style>
+    .navbar-brand .logo__title .backend-subtitle {
+      display: block;
+      margin-top: 0.35rem;
+      padding-left: 0.55rem;
+      font-size: 0.78em;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      opacity: 0.92;
+      color: inherit;
+      border-left: 2px solid transparent;
+    }
+
+    .navbar-brand .logo__title .backend-subtitle.backend-pytorch {
+      border-left-color: #ee4c2c;
+    }
+
+    .navbar-brand .logo__title .backend-subtitle.backend-tensorflow {
+      border-left-color: #f59e0b;
+    }
+
     #backend-switch {
       position: fixed;
       top: 1rem;
@@ -39,6 +59,29 @@
 
 
   <script>
+  (function injectBackendUnderTitle() {
+    const templateBackend = "{{ backend }}";
+    const inferredBackend = (window.location.pathname.match(/(pytorch|tensorflow)/) || [])[1] || "";
+    const currentBackend = (templateBackend || inferredBackend || "tensorflow").toLowerCase();
+
+    const titleNode = document.querySelector(".navbar-brand .logo__title");
+    if (!titleNode) return;
+
+    const titleText = (titleNode.textContent || "").toLowerCase();
+    if (titleText.includes("tensorflow backend") || titleText.includes("pytorch backend")) {
+      return;
+    }
+
+    if (titleNode.querySelector(".backend-subtitle")) {
+      return;
+    }
+
+    const subtitle = document.createElement("span");
+    subtitle.className = `backend-subtitle backend-${currentBackend}`;
+    subtitle.textContent = currentBackend === "pytorch" ? "PyTorch Backend" : "TensorFlow Backend";
+    titleNode.appendChild(subtitle);
+  })();
+
   function switchBackend(targetBackend) {
     const currentURL = window.location.href;
     const backendMatch = currentURL.match(/(pytorch|tensorflow)/);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,6 @@ The goal of DLOmix is to be easy to use and flexible, while still providing the 
 
 .. include:: notes/installation.rst
 .. include:: notes/quickstart.rst
-.. include:: notes/dataset_guide.rst
 
 
 

--- a/docs/notes/dataset_guide.rst
+++ b/docs/notes/dataset_guide.rst
@@ -346,7 +346,7 @@ Optimize dataset processing with these parameters:
 
    dataset = RetentionTimeDataset(
        data_source="large_dataset.parquet",
-       num_proc=4,                    # Use 4 CPU cores for processing
+       num_proc=-1,                   # Use all available CPU cores
        batch_processing_size=5000,    # Process 5000 rows at a time
        disable_cache=False,           # Enable HF datasets caching
        auto_cleanup_cache=True,       # Clean temp files after processing
@@ -355,7 +355,7 @@ Optimize dataset processing with these parameters:
 
 **Performance tips:**
 
-* ``num_proc``: Set to number of CPU cores for large datasets
+* ``num_proc``: Use ``-1`` for all available processors, ``None`` for single-process mode, or a positive integer for an explicit processor count
 * ``batch_processing_size``: Increase for better throughput (default: 1000)
 * ``enable_tf_dataset_cache``: Speeds up repeated iterations but uses more memory
 * ``disable_cache=False``: Reuses processed datasets across runs. This is the hugging face datasets caching mechanism.
@@ -507,6 +507,6 @@ Best Practices
 
 **Performance**
 
-* Set ``num_proc`` to match available CPU cores
+* Use ``num_proc=-1`` to use all available CPU cores, or set a smaller explicit value to reduce memory pressure
 * Use Parquet format for large datasets
 * Process data once and save with ``save_to_disk()``

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
     package_dir={"": "src"},
     include_package_data=True,
     package_data={"": ["data/processing/pickled_feature_dicts/*"]},
+    python_requires=">=3.10",
     install_requires=[
         "datasets>=4.0.0",
         "huggingface_hub",
@@ -72,10 +73,8 @@ setuptools.setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Bio-Informatics",

--- a/src/dlomix/_metadata.py
+++ b/src/dlomix/_metadata.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "Wilhelm Lab"
 __author_email__ = "o.shouman@tum.de"
 __license__ = "MIT"

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -33,7 +33,7 @@ class ChargeStateDataset(PeptideDataset):
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cache()` on the generated TF Datasets).
         disable_cache (bool): Whether to disable Hugging Face datasets caching. Default is False.
         auto_cleanup_cache (bool): Whether to automatically clean up the cache. Default is True.
-        num_proc (Optional[int]): Number of processes to use for dataset processing. Default is None.
+        num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
     """
@@ -63,7 +63,7 @@ class ChargeStateDataset(PeptideDataset):
         enable_tf_dataset_cache: bool = False,
         disable_cache: bool = False,
         auto_cleanup_cache: bool = True,
-        num_proc: Optional[int] = None,
+        num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
         **kwargs,

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Optional, Union
 from datasets import Dataset, DatasetDict, Sequence, Value, load_dataset
 
 from .dataset_config import DatasetConfig
-from .dataset_utils import EncodingScheme, get_num_processors
+from .dataset_utils import EncodingScheme, get_num_processors, resolve_num_proc
 from .processing.feature_extractors import (
     AVAILABLE_FEATURE_EXTRACTORS,
     FEATURE_EXTRACTORS_PARAMETERS,
@@ -80,7 +80,9 @@ class PeptideDataset:
     auto_cleanup_cache : bool
         Flag to indicate whether to automatically clean up the temporary Hugging Face Datasets cache files. Default is True.
     num_proc : Optional[int]
-        Number of processes to use for processing the dataset. Default is None, no multi-processing.
+        Number of processes to use for processing the dataset.
+        Set to ``-1`` to use all available processors, ``None`` to force single-process execution,
+        or a positive integer to use an explicit number of processors.
     batch_processing_size : Optional[int]
         Batch size for processing the dataset, passed to the HuggingFace `Dataset.map()` function calls. Default is 1000.
 
@@ -131,9 +133,9 @@ class PeptideDataset:
 
         # add padding value to the alphabet if not present
         if self.extended_alphabet.get(self.padding_value) is None:
-            self.extended_alphabet[
-                self.padding_value
-            ] = PeptideDataset.PADDING_VALUE_DEFAULT_INDEX
+            self.extended_alphabet[self.padding_value] = (
+                PeptideDataset.PADDING_VALUE_DEFAULT_INDEX
+            )
 
         self._config = dataset_config
 
@@ -169,19 +171,12 @@ class PeptideDataset:
 
     def _set_num_proc(self):
         n_processors = get_num_processors()
-        if self._num_proc:
-            if self._num_proc > n_processors:
-                warnings.warn(
-                    f"Number of processors provided is greater than the available processors. Using the maximum number of processors available: {n_processors}."
-                )
-                self._num_proc = n_processors
-        else:
+        self._num_proc, was_capped = resolve_num_proc(self._num_proc, n_processors)
+
+        if was_capped:
             warnings.warn(
-                f"Number of processors not provided. Using the maximum number of processors available: {n_processors}.\n"
-                f"If you want to specify a different number of processors, please provide num_proc=<desired_number> parameter in the dataset configuration.\n"
-                f"If you face issues with memory usage, please consider providing a smaller number of processors or setting num_proc=1 to disable multi-processing."
+                f"Number of processors provided is greater than the available processors. Using the maximum number of processors available: {n_processors}."
             )
-            self._num_proc = n_processors
 
     def _set_hf_cache_management(self):
         if self.disable_cache:
@@ -287,12 +282,10 @@ class PeptideDataset:
             self._is_predefined_split = True
 
         if self._is_predefined_split:
-            warnings.warn(
-                f"""
+            warnings.warn(f"""
                 Multiple data sources or a single non-train data source provided {self._data_files_available_splits}, please ensure that the data sources are already split into train, val and test sets
                 since no splitting will happen. If not, please provide only one data_source and set the val_ratio to split the data into train and val sets."
-                """
-            )
+                """)
 
     def _remove_unnecessary_columns(self):
         self._relevant_columns = [self.sequence_column, *self.label_column]
@@ -412,9 +405,9 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
                     ],
                     feature_column_name=feature_name,
                     **FEATURE_EXTRACTORS_PARAMETERS[feature_name],
-                    max_length=self.max_seq_len + 2
-                    if self.with_termini
-                    else self.max_seq_len,
+                    max_length=(
+                        self.max_seq_len + 2 if self.with_termini else self.max_seq_len
+                    ),
                     batched=True,
                 )
             elif isinstance(feature, Callable):
@@ -438,13 +431,8 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
 
     def _apply_processing_pipeline(self):
         for processor in self._processors:
-            for split in self.hf_dataset.keys():
-                logger.info(
-                    "Applying step: %s on split %s...",
-                    processor.__class__.__name__,
-                    split,
-                )
-
+            split_order = self._get_split_processing_order(processor)
+            for split in split_order:
                 logger.info(
                     "Applying step: %s on split %s...",
                     processor.__class__.__name__,
@@ -459,14 +447,25 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
                 if isinstance(processor, SequenceEncodingProcessor):
                     if split in PeptideDataset.DEFAULT_SPLIT_NAMES[0:2]:
                         # train/val split -> learn the alphabet unless otherwise specified
-                        self._apply_processor_to_split(processor, split)
+                        # force single processor to ensure that the alphabet is learned on the entire split and not just on a subset of the data when using multi-processing
+
+                        strictly_single_process = bool(
+                            getattr(processor, "extend_alphabet", False)
+                            or getattr(processor, "learning_alphabet_mode", False)
+                        )
+
+                        self._apply_processor_to_split(
+                            processor,
+                            split,
+                            force_single_processor=strictly_single_process,
+                        )
 
                         self.extended_alphabet = processor.alphabet.copy()
 
                     elif split == PeptideDataset.DEFAULT_SPLIT_NAMES[2]:
                         # test split -> use the learned alphabet from the train/val split
                         # and enable fallback to encoding unseen (AA, PTM) as unmodified Amino acids
-                        processor = SequenceEncodingProcessor(
+                        temp_test_processor = SequenceEncodingProcessor(
                             sequence_column_name=self.sequence_column,
                             alphabet=self.extended_alphabet,
                             batched=True,
@@ -474,7 +473,7 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
                             fallback_unmodified=True,
                         )
 
-                        self._apply_processor_to_split(processor, split)
+                        self._apply_processor_to_split(temp_test_processor, split)
 
                     else:
                         raise Warning(
@@ -504,15 +503,35 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
             SequencePaddingProcessor.KEEP_COLUMN_NAME
         )
 
+    def _get_split_processing_order(self, processor: PeptideDatasetBaseProcessor):
+        split_order = list(self.hf_dataset.keys())
+
+        # Ensure encoding sees train/val before test so test uses full learned vocab.
+        if isinstance(processor, SequenceEncodingProcessor):
+            ordered_default = [
+                split
+                for split in PeptideDataset.DEFAULT_SPLIT_NAMES
+                if split in self.hf_dataset
+            ]
+            non_default = [
+                split for split in split_order if split not in ordered_default
+            ]
+            return ordered_default + non_default
+
+        return split_order
+
     def _apply_processor_to_split(
-        self, processor: PeptideDatasetBaseProcessor, split: str
+        self,
+        processor: PeptideDatasetBaseProcessor,
+        split: str,
+        force_single_processor: bool = False,
     ):
         self.hf_dataset[split] = self.hf_dataset[split].map(
             processor,
             desc=f"Mapping {processor.__class__.__name__}",
             batched=processor.batched,
             batch_size=self.batch_processing_size,
-            num_proc=self._num_proc,
+            num_proc=None if force_single_processor else self._num_proc,
         )
 
     def _cast_model_feature_types_to_float(self):
@@ -758,9 +777,11 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
         return self.hf_dataset[split_name].to_tf_dataset(
             columns=self._get_input_tensor_column_names(),
             label_cols=label_cols,
-            shuffle=self.shuffle
-            if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
-            else False,
+            shuffle=(
+                self.shuffle
+                if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
+                else False
+            ),
             batch_size=self.batch_size,
         )
 
@@ -776,9 +797,11 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
                 columns=[*self._get_input_tensor_column_names(), *self.label_column],
             ),
             "batch_size": self.batch_size,
-            "shuffle": self.shuffle
-            if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
-            else False,
+            "shuffle": (
+                self.shuffle
+                if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
+                else False
+            ),
         }
 
         # Update with user-provided torch_dataloader_kwargs if available

--- a/src/dlomix/data/dataset_config.py
+++ b/src/dlomix/data/dataset_config.py
@@ -3,7 +3,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Union
 
-from .dataset_utils import EncodingScheme
+from .dataset_utils import EncodingScheme, validate_num_proc_value
 
 
 @dataclass
@@ -54,6 +54,8 @@ class DatasetConfig:
             )
         elif isinstance(self.label_column, str):
             self.label_column = [self.label_column]
+
+        validate_num_proc_value(self.num_proc)
 
     def save_config_json(self, path: str):
         """

--- a/src/dlomix/data/dataset_utils.py
+++ b/src/dlomix/data/dataset_utils.py
@@ -31,3 +31,51 @@ def get_num_processors():
     import multiprocessing
 
     return multiprocessing.cpu_count()
+
+
+def validate_num_proc_value(num_proc):
+    """
+    Validate the user-provided num_proc value.
+
+    Allowed values:
+    - None: force single-process execution
+    - -1: use all available processors
+    - positive integer: explicit number of processors
+    """
+
+    if num_proc is None:
+        return
+
+    if not isinstance(num_proc, int):
+        raise ValueError(
+            "The num_proc parameter should be None, -1, or a positive integer."
+        )
+
+    if num_proc != -1 and num_proc <= 0:
+        raise ValueError(
+            "Invalid num_proc value. Use None for single-process mode, -1 for all available processors, or a positive integer."
+        )
+
+
+def resolve_num_proc(num_proc, n_processors):
+    """
+    Resolve num_proc to the effective value used by HF Dataset map/filter calls.
+
+    Returns
+    -------
+    tuple
+        (resolved_num_proc, was_capped)
+    """
+
+    validate_num_proc_value(num_proc)
+
+    if num_proc is None:
+        return None, False
+
+    if num_proc == -1:
+        return n_processors, False
+
+    if num_proc > n_processors:
+        return n_processors, True
+
+    return num_proc, False

--- a/src/dlomix/data/detectability.py
+++ b/src/dlomix/data/detectability.py
@@ -33,7 +33,7 @@ class DetectabilityDataset(PeptideDataset):
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cache()` on the generated TF Datasets).
         disable_cache (bool): Whether to disable Hugging Face datasets caching. Default is False.
         auto_cleanup_cache (bool): Whether to automatically clean up the cache. Default is True.
-        num_proc (Optional[int]): Number of processes to use for dataset processing. Default is None.
+        num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
     """
@@ -63,7 +63,7 @@ class DetectabilityDataset(PeptideDataset):
         enable_tf_dataset_cache: bool = False,
         disable_cache: bool = False,
         auto_cleanup_cache: bool = True,
-        num_proc: Optional[int] = None,
+        num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
         **kwargs,

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -37,7 +37,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cache()` on the generated TF Datasets). Default is False.
         disable_cache (bool): Whether to disable Hugging Face datasets caching. Default is False.
         auto_cleanup_cache (bool): Whether to automatically clean up the cache. Default is True.
-        num_proc (Optional[int]): Number of processes to use for dataset processing. Default is None.
+        num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
         **kwargs: Additional arguments to pass to the parent class.
@@ -68,7 +68,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         enable_tf_dataset_cache: bool = False,
         disable_cache: bool = False,
         auto_cleanup_cache: bool = True,
-        num_proc: Optional[int] = None,
+        num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
         **kwargs,

--- a/src/dlomix/data/ion_mobility.py
+++ b/src/dlomix/data/ion_mobility.py
@@ -34,6 +34,7 @@ class IonMobilityDataset(PeptideDataset):
         processed (bool): Whether the dataset has been preprocessed. Defaults to False.
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cache()` on the generated TF Datasets).
         disable_cache (bool): Whether to disable Hugging Face datasets caching. Default is False.
+        num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
     """
 
     def __init__(
@@ -60,7 +61,7 @@ class IonMobilityDataset(PeptideDataset):
         enable_tf_dataset_cache: bool = False,
         disable_cache: bool = False,
         auto_cleanup_cache: bool = True,
-        num_proc: Optional[int] = None,
+        num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
     ):
         kwargs = {k: v for k, v in locals().items() if k not in ["self", "__class__"]}

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -33,7 +33,7 @@ class RetentionTimeDataset(PeptideDataset):
         enable_tf_dataset_cache (bool): Flag to indicate whether to enable TensorFlow Dataset caching (call `.cache()` on the generated TF Datasets).
         disable_cache (bool): Whether to disable Hugging Face datasets caching. Default is False.
         auto_cleanup_cache (bool): Whether to automatically clean up the cache. Default is True.
-        num_proc (Optional[int]): Number of processes to use for dataset processing. Default is None.
+        num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
     """
@@ -63,7 +63,7 @@ class RetentionTimeDataset(PeptideDataset):
         enable_tf_dataset_cache: bool = False,
         disable_cache: bool = False,
         auto_cleanup_cache: bool = True,
-        num_proc: Optional[int] = None,
+        num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
         **kwargs,

--- a/src/dlomix/eval/__init__.py
+++ b/src/dlomix/eval/__init__.py
@@ -4,7 +4,10 @@ if _BACKEND in TENSORFLOW_BACKEND:
     from .chargestate import adjusted_mean_absolute_error, adjusted_mean_squared_error
     from .rt_eval import TimeDeltaMetric, timedelta
 elif _BACKEND in PYTORCH_BACKEND:
-    from .chargestate_torch import adjusted_mean_absolute_error, adjusted_mean_squared_error
+    from .chargestate_torch import (
+        adjusted_mean_absolute_error,
+        adjusted_mean_squared_error,
+    )
     from .rt_eval_torch import TimeDeltaMetric, timedelta
 
 __all__ = [

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -10,6 +10,7 @@ from dlomix.data import (
     RetentionTimeDataset,
     load_processed_dataset,
 )
+from dlomix.data.dataset_utils import EncodingScheme
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,30 @@ def test_empty_rtdataset():
     rtdataset = RetentionTimeDataset()
     assert rtdataset.hf_dataset is None
     assert rtdataset._empty_dataset_mode is True
+
+
+def test_num_proc_minus_one_uses_available_processors(monkeypatch):
+    monkeypatch.setattr("dlomix.data.dataset.get_num_processors", lambda: 6)
+
+    dataset = RetentionTimeDataset(num_proc=-1)
+
+    assert dataset._num_proc == 6
+
+
+def test_num_proc_none_forces_single_process(monkeypatch):
+    monkeypatch.setattr("dlomix.data.dataset.get_num_processors", lambda: 6)
+
+    dataset = RetentionTimeDataset(num_proc=None)
+
+    assert dataset._num_proc is None
+
+
+def test_num_proc_user_value_is_capped_to_available(monkeypatch):
+    monkeypatch.setattr("dlomix.data.dataset.get_num_processors", lambda: 6)
+
+    dataset = RetentionTimeDataset(num_proc=10)
+
+    assert dataset._num_proc == 6
 
 
 def test_parquet_rtdataset(download_path_for_assets):
@@ -275,6 +300,86 @@ def test_no_split_datasetDict_hf_inmemory(raw_generic_nested_data):
     )
 
     # test learning alphabet for train/val and then using it for test with fallback
+
+
+def _make_rt_split_data(seqs):
+    return Dataset.from_dict(
+        {
+            "modified_sequence": seqs,
+            "indexed_retention_time": [0.1 + i for i in range(len(seqs))],
+        }
+    )
+
+
+def test_encoding_learning_forces_single_process(monkeypatch):
+    # Keep split insertion order as train -> test -> val to capture ordering assumptions.
+    hf_dataset = DatasetDict(
+        {
+            "train": _make_rt_split_data(["[]-AC-[]"]),
+            "test": _make_rt_split_data(["[]-C[UNIMOD:4]A-[]"]),
+            "val": _make_rt_split_data(["[]-C[UNIMOD:4]A-[]"]),
+        }
+    )
+
+    calls = []
+    original_map = Dataset.map
+
+    def map_spy(self, function, *args, **kwargs):
+        calls.append((kwargs.get("desc"), kwargs.get("num_proc")))
+        return original_map(self, function, *args, **kwargs)
+
+    monkeypatch.setattr(Dataset, "map", map_spy)
+
+    RetentionTimeDataset(
+        data_format="hf",
+        data_source=hf_dataset,
+        sequence_column="modified_sequence",
+        label_column="indexed_retention_time",
+        encoding_scheme=EncodingScheme.NAIVE_MODS,
+        alphabet=None,
+        num_proc=2,
+        max_seq_len=8,
+    )
+
+    encoding_calls = [c for c in calls if c[0] == "Mapping SequenceEncodingProcessor"]
+    assert len(encoding_calls) == 3
+
+    # Encoding is deterministic train -> val -> test.
+    # train/val must force single-process learning, test keeps configured num_proc.
+    assert encoding_calls[0][1] is None
+    assert encoding_calls[1][1] is None
+    assert encoding_calls[2][1] == 2
+
+
+def test_val_tokens_available_to_test_even_with_nonstandard_split_order():
+    # Token appears in val and test, but not train. If test is encoded before val,
+    # fallback may be used incorrectly instead of learned token encoding.
+    hf_dataset = DatasetDict(
+        {
+            "train": _make_rt_split_data(["[]-AC-[]"]),
+            "test": _make_rt_split_data(["[]-C[UNIMOD:4]A-[]"]),
+            "val": _make_rt_split_data(["[]-C[UNIMOD:4]A-[]"]),
+        }
+    )
+
+    dataset = RetentionTimeDataset(
+        data_format="hf",
+        data_source=hf_dataset,
+        sequence_column="modified_sequence",
+        label_column="indexed_retention_time",
+        encoding_scheme=EncodingScheme.NAIVE_MODS,
+        alphabet=None,
+        num_proc=2,
+        max_seq_len=8,
+    )
+
+    assert "C[UNIMOD:4]" in dataset.extended_alphabet
+
+    test_encoded = dataset.hf_dataset["test"][0]["modified_sequence"]
+    learned_token_index = dataset.extended_alphabet["C[UNIMOD:4]"]
+
+    # with_termini=True means sequence starts with []- at index 0.
+    assert test_encoded[1] == learned_token_index
 
 
 def test_shuffle_parameter(raw_generic_nested_data):


### PR DESCRIPTION
## Changes:

- multi-processing issues in datasets when learning the vocabulary:
   - force single process for encoding processing with `num_proc=None`
- train, val, test processing order strictly enforced to avoid test being processed before train or val when learning the alphabet
- minor docs updates to sanitize index.rst and display the backend in a more visible way