### PR TITLE
Feature/dataset refactor inference pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ run_scripts/output/
 assets/
 
 src/dlomix/reports/quarto/.local_quarto_plots
+
+# Claude Code project instructions (local, not checked in)
+CLAUDE.md

--- a/docs/dlomix.data.processing.rst
+++ b/docs/dlomix.data.processing.rst
@@ -10,6 +10,12 @@ Submodules
 ----------
 
 
+.. automodule:: dlomix.data.processing.chain
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.data.processing.feature_extractors
    :members:
    :undoc-members:
@@ -17,6 +23,12 @@ Submodules
 
 
 .. automodule:: dlomix.data.processing.feature_tables
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.data.processing.pipeline
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/dlomix.data.rst
+++ b/docs/dlomix.data.rst
@@ -36,6 +36,12 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: dlomix.data.dataset_splitter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.data.dataset_utils
    :members:
    :undoc-members:

--- a/docs/dlomix.data.rst
+++ b/docs/dlomix.data.rst
@@ -60,13 +60,37 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: dlomix.data.inference
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.data.ion_mobility
    :members:
    :undoc-members:
    :show-inheritance:
 
 
+.. automodule:: dlomix.data.loading
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: dlomix.data.retention_time
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.data.serialization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: dlomix.data.tensor_conversion
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/dlomix.pipelines.rst
+++ b/docs/dlomix.pipelines.rst
@@ -14,3 +14,9 @@ Submodules
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+.. automodule:: dlomix.pipelines.predictor
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/notes/dataset_guide.rst
+++ b/docs/notes/dataset_guide.rst
@@ -429,6 +429,76 @@ The tensor datasets can be accessed via the ``train_data``, ``val_data``, and ``
             **kwargs)
 
 
+Inference on New Data
+=====================
+
+To predict on new, unlabelled peptides you need the *exact* preprocessing used at
+training time (the learned alphabet, encoding scheme, padding, feature extractors).
+``PeptidePreprocessor`` captures that recipe and applies it to raw inputs, so you do not
+have to reconstruct a full dataset or remember the original parameters.
+
+Preprocess raw inputs
+---------------------
+
+Derive a preprocessor from a processed dataset, then call it on raw sequences. The output
+is the same tensor object the model consumes during training (a ``tf.data.Dataset`` or a
+torch ``DataLoader`` depending on ``dataset_type``):
+
+.. code-block:: python
+
+   prep = dataset.get_preprocessor()
+
+   tensors = prep(["PEPTIDEK", "ACDEM[UNIMOD:35]K"])   # raw -> model-ready tensors
+   predictions = model.predict(tensors)
+
+Accepted input formats: a single string, a list/``numpy`` array of strings, a ``dict``
+that also carries ``model_features`` (e.g. ``collision_energy``, ``precursor_charge``),
+a ``pandas`` DataFrame, or an in-memory HuggingFace ``Dataset``.
+
+A preprocessor can also be rebuilt from a saved dataset directory (no need to load the
+data), or saved/loaded as its own small artifact for shipping next to a model:
+
+.. code-block:: python
+
+   from dlomix.data import PeptidePreprocessor
+
+   # from a save_to_disk() directory (reads config + metadata only)
+   prep = PeptidePreprocessor.from_saved("processed_datasets/rt_dataset")
+
+   # standalone lightweight artifact
+   prep.save("rt_preprocessor")
+   prep = PeptidePreprocessor.load("rt_preprocessor")
+
+.. note::
+   Custom *callable* feature extractors cannot be serialized. They are preserved by
+   ``get_preprocessor()`` (in-memory) but dropped by ``save()`` / ``from_saved()`` with a
+   warning. Built-in feature names (strings) are always restored.
+
+Bundle a model with its preprocessor
+-------------------------------------
+
+``InferencePipeline`` ties a trained model together with its preprocessor so inference is
+a single ``predict`` call on raw inputs, and both travel together as one saved artifact
+(similar to a HuggingFace tokenizer + model):
+
+.. code-block:: python
+
+   from dlomix.pipelines import InferencePipeline
+
+   pipeline = InferencePipeline.from_model_and_dataset(model, dataset)
+   predictions = pipeline.predict(["PEPTIDEK", "ACDEK"])   # numpy array
+
+   pipeline.save("my_rt_model")                  # preprocessor + model weights + metadata
+   pipeline = InferencePipeline.load("my_rt_model")
+   predictions = pipeline.predict(["PEPTIDEK", "ACDEK"])
+
+On construction and on load, the pipeline checks that the model's embedding vocabulary
+size matches the preprocessor's alphabet and raises a ``ValueError`` on mismatch, guarding
+against accidentally pairing a model with the wrong preprocessor. The backend
+(TensorFlow/PyTorch) is selected at import time via ``DLOMIX_BACKEND``; a pipeline must be
+loaded under the same backend it was saved with.
+
+
 Advanced Features
 =================
 

--- a/docs/notes/dataset_guide.rst
+++ b/docs/notes/dataset_guide.rst
@@ -116,22 +116,22 @@ Core Concepts
 Data Splits and Validation
 ---------------------------
 
-DLOmix supports three splitting strategies:
+DLOmix supports three high-level data source modes:
 
-1. **Single source with auto-split**: Set ``val_ratio`` to automatically split training data into train/val randomly
-2. **Multiple sources**: Provide separate files for train/val/test
-3. **Pre-split datasets**: Use HuggingFace Hub or ``DatasetDict`` with existing splits
+1. **Single source with auto-split**: Provide only ``data_source``; DLOmix splits it automatically using the configured strategy.
+2. **Multiple sources**: Provide separate files for train/val/test; no splitting is performed.
+3. **Pre-split datasets**: Use a HuggingFace Hub dataset or pass a ``DatasetDict``; splits are used as-is.
 
 .. code-block:: python
 
-   # Strategy 1: Auto-split
+   # Mode 1: Auto-split (random by default)
    dataset = RetentionTimeDataset(
        data_source="train.csv",
-       val_ratio=0.2,  # 20% for validation
+       val_ratio=0.2,        # 20% for validation
        data_format="csv"
    )
 
-   # Strategy 2: Separate files
+   # Mode 2: Separate files
    dataset = RetentionTimeDataset(
        data_source="train.csv",
        val_data_source="val.csv",
@@ -139,10 +139,91 @@ DLOmix supports three splitting strategies:
        data_format="csv"
    )
 
-   # Strategy 3: pre-split dataset (example below points to a remote hugging face dataset hosted on the hub)
+   # Mode 3: Pre-split dataset from the HF Hub
    dataset = RetentionTimeDataset(
        data_source="wilhelmlab/prospect-rt",
        data_format="hub"
+   )
+
+.. note::
+   Splitting parameters (``split_strategy``, ``split_seed``, ``test_ratio``, ``stratify_by_column``) are only valid in **Mode 1**. Providing them alongside pre-defined sources raises a ``ValueError``.
+
+Splitting Strategies
+--------------------
+
+When using auto-split (Mode 1), the splitting strategy is controlled by the ``split_strategy`` parameter.
+Three strategies are available:
+
+**Random** (default)
+
+Shuffles and splits the data randomly. Use ``split_seed`` for reproducible results.
+
+.. code-block:: python
+
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       val_ratio=0.2,
+       split_strategy="random",
+       split_seed=42            # optional, for reproducibility
+   )
+
+**Sequence-unique**
+
+Ensures that the same peptide sequence never appears in both train and validation sets.
+This prevents data leakage when a dataset contains multiple measurements for the same sequence
+(e.g. multiple charge states or collision energies for the same peptide).
+
+.. code-block:: python
+
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       val_ratio=0.2,
+       split_strategy="sequence_unique",
+       split_seed=42
+   )
+
+**Stratified**
+
+Splits while preserving the class distribution of a specified column. Requires
+``stratify_by_column`` to point to a column with a ``ClassLabel`` feature type (as defined
+by the HuggingFace ``datasets`` library).
+
+.. code-block:: python
+
+   from datasets import ClassLabel, Features, Value
+
+   # The column used for stratification must have a ClassLabel type
+   dataset = ChargeStateDataset(
+       data_source="data.csv",
+       val_ratio=0.2,
+       split_strategy="stratified",
+       stratify_by_column="charge"   # must be a ClassLabel column
+   )
+
+Three-way Splits
+-----------------
+
+All three strategies support an optional ``test_ratio`` parameter that carves out a held-out test
+set in a single pass, producing train/val/test from a single source file.
+
+.. code-block:: python
+
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       val_ratio=0.15,
+       test_ratio=0.15,          # remaining 70% goes to train
+       split_strategy="random",
+       split_seed=42
+   )
+
+   # Also works with sequence_unique to ensure no leakage across all three splits
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       val_ratio=0.15,
+       test_ratio=0.15,
+       split_strategy="sequence_unique",
+       test_uniqueness=True,     # default; sequences are unique across all three splits
+       split_seed=42
    )
 
 
@@ -479,6 +560,14 @@ DatasetConfig Parameters
 * ``dataset_type``: ``"tf"`` or ``"pt"``
 * ``shuffle``: Shuffle data (default: False)
 
+**Splitting** (only used when a single ``data_source`` is provided)
+
+* ``split_strategy``: Splitting strategy — ``"random"`` (default), ``"sequence_unique"``, or ``"stratified"``
+* ``split_seed``: Integer seed for reproducible splits (default: ``None``)
+* ``test_ratio``: Fraction of data to hold out as a test set for three-way splits (default: ``None``, train/val only)
+* ``stratify_by_column``: Column name to stratify by; required when ``split_strategy="stratified"`` (default: ``None``)
+* ``test_uniqueness``: When ``split_strategy="sequence_unique"``, ensures test sequences are also unique from train/val (default: ``True``)
+
 
 Best Practices
 ==============
@@ -497,8 +586,11 @@ Best Practices
 
 **Validation Splits**
 
-* Prefer explicit ``val_data_source`` for consistent evaluation
-* Always use a separate test dataset for final evaluation, can also be created independently using another Dataset instance with ``test_data_source`` only.
+* Prefer explicit ``val_data_source`` for consistent evaluation across runs
+* Use ``split_seed`` when relying on auto-split so results are reproducible
+* Use ``split_strategy="sequence_unique"`` when your dataset has multiple rows per peptide (e.g. multiple charge states) to prevent the same sequence from leaking across train and validation
+* Use ``split_strategy="stratified"`` for imbalanced classification tasks to preserve class proportions in each split
+* Always use a separate test dataset for final evaluation — either via ``test_data_source`` or ``test_ratio`` in a three-way auto-split
 
 **Feature Engineering**
 

--- a/docs/notes/dataset_guide.rst
+++ b/docs/notes/dataset_guide.rst
@@ -146,7 +146,42 @@ DLOmix supports three high-level data source modes:
    )
 
 .. note::
-   Splitting parameters (``split_strategy``, ``split_seed``, ``test_ratio``, ``stratify_by_column``) are only valid in **Mode 1**. Providing them alongside pre-defined sources raises a ``ValueError``.
+   Splitting parameters (``val_ratio``, ``test_ratio``, ``split_strategy``, ``stratify_by_column``) are only valid in **Mode 1**. Providing them alongside pre-defined sources raises a ``ValueError``.
+
+The table below summarises all combinations of data sources and split parameters and their outcome:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 44 10 24
+
+   * - Situation
+     - Example parameters
+     - Ratios set?
+     - Outcome
+   * - Single train source
+     - ``data_source="train.csv", val_ratio=0.2``
+     - yes
+     - Auto-split using the configured strategy
+   * - Multiple sources
+     - ``data_source="train.csv", val_data_source="val.csv"``
+     - no
+     - Splits used as-is; warns that no auto-split occurs
+   * - Multiple sources
+     - ``data_source="train.csv", val_data_source="val.csv", val_ratio=0.2``
+     - yes
+     - ``ValueError``
+   * - HF Hub or DatasetDict
+     - ``data_source="hub/dataset", data_format="hub"``
+     - no
+     - Splits used as-is; warns that no auto-split occurs
+   * - Test-only source
+     - ``test_data_source="test.csv"``
+     - no
+     - Test data used as-is; warns that no auto-split occurs
+   * - Test-only source
+     - ``test_data_source="test.csv", val_ratio=0.2``
+     - yes
+     - ``ValueError``
 
 Splitting Strategies
 --------------------
@@ -169,7 +204,7 @@ Shuffles and splits the data randomly. Use ``split_seed`` for reproducible resul
 
 **Sequence-unique**
 
-Ensures that the same peptide sequence never appears in both train and validation sets.
+Ensures that the same peptide sequence never appears in more than one split.
 This prevents data leakage when a dataset contains multiple measurements for the same sequence
 (e.g. multiple charge states or collision energies for the same peptide).
 
@@ -184,39 +219,50 @@ This prevents data leakage when a dataset contains multiple measurements for the
 
 **Stratified**
 
-Splits while preserving the class distribution of a specified column. Requires
-``stratify_by_column`` to point to a column with a ``ClassLabel`` feature type (as defined
-by the HuggingFace ``datasets`` library).
+Splits while preserving the class distribution of a specified column. The column should have
+a ``ClassLabel`` feature type (as defined by the HuggingFace ``datasets`` library); if it
+does not, DLOmix will auto-cast it and emit a warning.
 
 .. code-block:: python
 
-   from datasets import ClassLabel, Features, Value
-
-   # The column used for stratification must have a ClassLabel type
    dataset = ChargeStateDataset(
        data_source="data.csv",
        val_ratio=0.2,
        split_strategy="stratified",
-       stratify_by_column="charge"   # must be a ClassLabel column
+       stratify_by_column="charge"
    )
 
-Three-way Splits
------------------
+Multi-split Configurations
+---------------------------
 
-All three strategies support an optional ``test_ratio`` parameter that carves out a held-out test
-set in a single pass, producing train/val/test from a single source file.
+``val_ratio`` and ``test_ratio`` are independent — set either or both. At least one must be provided when auto-splitting.
 
 .. code-block:: python
 
+   # train/val only
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       val_ratio=0.2,
+       split_seed=42
+   )
+
+   # train/test only (no val split)
+   dataset = RetentionTimeDataset(
+       data_source="data.csv",
+       test_ratio=0.2,
+       split_seed=42
+   )
+
+   # train/val/test — remaining fraction goes to train
    dataset = RetentionTimeDataset(
        data_source="data.csv",
        val_ratio=0.15,
-       test_ratio=0.15,          # remaining 70% goes to train
+       test_ratio=0.15,          # remaining 70% → train
        split_strategy="random",
        split_seed=42
    )
 
-   # Also works with sequence_unique to ensure no leakage across all three splits
+   # sequence_unique also works for all three configurations
    dataset = RetentionTimeDataset(
        data_source="data.csv",
        val_ratio=0.15,
@@ -451,7 +497,7 @@ Save processed datasets to disk to avoid reprocessing:
    # Save processed dataset
    dataset = RetentionTimeDataset(
        data_source="train.csv",
-       val_ratio=0.2
+       val_ratio=0.2        # required — no default
    )
    dataset.save_to_disk("processed_datasets/rt_dataset")
 
@@ -554,16 +600,16 @@ DatasetConfig Parameters
 
 **Training**
 
-* ``val_ratio``: Validation split ratio (0-1)
 * ``batch_size``: Batch size for tensor datasets
 * ``dataset_type``: ``"tf"`` or ``"pt"``
 * ``shuffle``: Shuffle data (default: False)
 
 **Splitting** (only used when a single ``data_source`` is provided)
 
+* ``val_ratio``: Fraction of data for the validation split. ``None`` or ``0`` means no val split (default: ``None``)
+* ``test_ratio``: Fraction of data for the test split. ``None`` or ``0`` means no test split (default: ``None``). At least one of ``val_ratio`` / ``test_ratio`` must be set when auto-splitting.
 * ``split_strategy``: Splitting strategy — ``"random"`` (default), ``"sequence_unique"``, or ``"stratified"``
 * ``split_seed``: Integer seed for reproducible splits (default: ``None``)
-* ``test_ratio``: Fraction of data to hold out as a test set for three-way splits (default: ``None``, train/val only)
 * ``stratify_by_column``: Column name to stratify by; required when ``split_strategy="stratified"`` (default: ``None``)
 
 

--- a/docs/notes/dataset_guide.rst
+++ b/docs/notes/dataset_guide.rst
@@ -222,7 +222,6 @@ set in a single pass, producing train/val/test from a single source file.
        val_ratio=0.15,
        test_ratio=0.15,
        split_strategy="sequence_unique",
-       test_uniqueness=True,     # default; sequences are unique across all three splits
        split_seed=42
    )
 
@@ -566,7 +565,6 @@ DatasetConfig Parameters
 * ``split_seed``: Integer seed for reproducible splits (default: ``None``)
 * ``test_ratio``: Fraction of data to hold out as a test set for three-way splits (default: ``None``, train/val only)
 * ``stratify_by_column``: Column name to stratify by; required when ``split_strategy="stratified"`` (default: ``None``)
-* ``test_uniqueness``: When ``split_strategy="sequence_unique"``, ensures test sequences are also unique from train/val (default: ``True``)
 
 
 Best Practices

--- a/notebooks/Example_InferencePipeline_Workflow.ipynb
+++ b/notebooks/Example_InferencePipeline_Workflow.ipynb
@@ -1,0 +1,1129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Inference Workflow with DLOmix\n",
+    "\n",
+    "How to run a trained model on **new, unlabelled peptides** without rebuilding a dataset or\n",
+    "remembering the training preprocessing. Two pieces do the work:\n",
+    "\n",
+    "- **`PeptidePreprocessor`** — reproduces the exact training-time preprocessing (alphabet,\n",
+    "  encoding, padding, features) and turns raw sequences into model-ready tensors.\n",
+    "- **`InferencePipeline`** — bundles a model with its preprocessor for one-call `predict` and\n",
+    "  a single save/load artifact.\n",
+    "\n",
+    "We cover three options: (1) inference right after training, (2) saving a bundle, and\n",
+    "(3) inference-only in a fresh session with no training and no dataset."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-01",
+   "metadata": {},
+   "source": [
+    "> The backend (TensorFlow/PyTorch) is chosen from `DLOMIX_BACKEND` **before** importing\n",
+    "> dlomix. This notebook uses the default (TensorFlow)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow Backend for DLOmix. To change the backend, set the DLOMIX_BACKEND environment variable to tensorflow or pytorch and re-import DLOmix.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# import os; os.environ['DLOMIX_BACKEND'] = 'tensorflow'  # set before importing dlomix\n",
+    "import numpy as np\n",
+    "from datasets import Dataset\n",
+    "\n",
+    "from dlomix.data import RetentionTimeDataset, PeptidePreprocessor\n",
+    "from dlomix.models import PrositRetentionTimePredictor\n",
+    "from dlomix.pipelines import InferencePipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {},
+   "source": [
+    "## 1. A trained model + dataset (mocked)\n",
+    "\n",
+    "Replace this cell with your real data and training. Here we build a tiny in-memory dataset\n",
+    "and run a 1-epoch fit just so the model exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-04",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/Omar/Documents/VSCode_repos/dlomix/dlomix/src/dlomix/data/loading.py:117: UserWarning: data_format=\"hf\" with a Dataset: the dataset will be automatically split into train/val (and optionally test) according to the split configuration. val_data_source and test_data_source are ignored.\n",
+      "  warnings.warn(\n",
+      "/Users/Omar/Documents/VSCode_repos/dlomix/dlomix/src/dlomix/data/processing/chain.py:64: UserWarning: Encoding scheme is EncodingScheme.UNMOD, this enforces removing all occurences of PTMs in the sequences. If you prefer to encode the (amino-acids)+PTM combinations as tokens in the vocabulary, please use the encoding scheme 'naive-mods'.\n",
+      "  warnings.warn(\n",
+      "/Users/Omar/Documents/VSCode_repos/dlomix/dlomix/src/dlomix/data/processing/processors.py:390: UserWarning: The unknown token 'X' is not present in the provided alphabet. It will be added with index 1.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de86972dd83d4d3cb7c170ae4be907be",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequenceParsingProcessor on split train (num_proc=10):   0%|          | 0/38 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "48fe990c92884640abae5e6b9812f8ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequenceParsingProcessor on split val (num_proc=10):   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9496504c26524539a72dc391a9a38a5f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequencePTMRemovalProcessor on split train (num_proc=10):   0%|          | 0/38 [00:00<?, ? examples/s…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8f2dddeb137148e2a29ffab8e1a4e5f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequencePTMRemovalProcessor on split val (num_proc=10):   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b6ab2b129a5c41eb8303e8e608aa97f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequenceEncodingProcessor on split train:   0%|          | 0/38 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "654e101037be4929994ab8bec3f159b1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequenceEncodingProcessor on split val:   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "393f9f23b66d414d976d8cda79aaa018",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequencePaddingProcessor on split train (num_proc=10):   0%|          | 0/38 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e2ab7608d0fa4cdcae5e1c79b53cb3da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter (num_proc=10):   0%|          | 0/38 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "141b6c85cb574cceb3fde25c4b103ba0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Mapping SequencePaddingProcessor on split val (num_proc=10):   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2922a04cafb461c951ce8cfc5182a2b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filter (num_proc=10):   0%|          | 0/10 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-23 15:16:34.353025: I metal_plugin/src/device/metal_device.cc:1154] Metal device set to: Apple M1 Max\n",
+      "2026-06-23 15:16:34.353064: I metal_plugin/src/device/metal_device.cc:296] systemMemory: 32.00 GB\n",
+      "2026-06-23 15:16:34.353071: I metal_plugin/src/device/metal_device.cc:313] maxCacheSize: 12.48 GB\n",
+      "2026-06-23 15:16:34.353108: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:306] Could not identify NUMA node of platform GPU ID 0, defaulting to 0. Your kernel may not have been built with NUMA support.\n",
+      "2026-06-23 15:16:34.353125: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:272] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 0 MB memory) -> physical PluggableDevice (device: 0, name: METAL, pci bus id: <undefined>)\n",
+      "/Users/Omar/miniconda3/envs/dlx/lib/python3.11/site-packages/datasets/arrow_dataset.py:405: FutureWarning: The output of `to_tf_dataset` will change when a passing single element list for `labels` or `columns` in the next datasets version. To return a tuple structure rather than dict, pass a single string.\n",
+      "Old behaviour: columns=['a'], labels=['labels'] -> (tf.Tensor, tf.Tensor)  \n",
+      "             : columns='a', labels='labels' -> (tf.Tensor, tf.Tensor)  \n",
+      "New behaviour: columns=['a'],labels=['labels'] -> ({'a': tf.Tensor}, {'labels': tf.Tensor})  \n",
+      "             : columns='a', labels='labels' -> (tf.Tensor, tf.Tensor) \n",
+      "  warnings.warn(\n",
+      "2026-06-23 15:16:36.890524: I tensorflow/core/grappler/optimizers/custom_graph_optimizer_registry.cc:117] Plugin optimizer for device_type GPU is enabled.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<keras.src.callbacks.History at 0x3a40093d0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# mock data: peptide sequences + a retention-time label\n",
+    "seqs = ['ACDEFGHIK', 'PEPTIDEK', 'MKLVAAR', 'GGGGSSSK', 'ACDEFGHIKLMN', 'PEPK'] * 8\n",
+    "data = {'modified_sequence': seqs, 'indexed_retention_time': [float(len(s)) for s in seqs]}\n",
+    "\n",
+    "dataset = RetentionTimeDataset(\n",
+    "    data_source=Dataset.from_dict(data),\n",
+    "    data_format='hf',\n",
+    "    sequence_column='modified_sequence',\n",
+    "    label_column='indexed_retention_time',\n",
+    "    val_ratio=0.2,\n",
+    "    max_seq_len=20,\n",
+    "    batch_size=8,\n",
+    ")\n",
+    "\n",
+    "model = PrositRetentionTimePredictor(seq_length=22, alphabet=dataset.extended_alphabet)\n",
+    "model.compile(optimizer='adam', loss='mse')\n",
+    "model.fit(dataset.tensor_train_data, validation_data=dataset.tensor_val_data,\n",
+    "          epochs=1, verbose=0)  # mock training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "## 2. Inference right after training (in-notebook)\n",
+    "\n",
+    "**Option A — preprocessor + `model.predict`.** Get the preprocessor from the dataset and\n",
+    "call it on raw sequences; the output is exactly what the model consumes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b33e629d-1c13-4f17-8811-464df974368b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#model.predict(prep(new_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:08:37.990796Z",
+     "iopub.status.busy": "2026-06-19T18:08:37.990720Z",
+     "iopub.status.idle": "2026-06-19T18:08:38.502899Z",
+     "shell.execute_reply": "2026-06-19T18:08:38.502624Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/Omar/Documents/VSCode_repos/dlomix/dlomix/src/dlomix/data/processing/processors.py:368: UserWarning: The unknown token 'X' is already present in the provided alphabet with index 1. If you prefer the default behavior, consider removing it from the alphabet and it will have the default index of 1.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26f259b62e24459eaddaf3afb5461832",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e3771db43fe4ac39a7aa0e3b7417fd3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "288ec44e8c7b45e4b7c43a302e16260d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "becf432e4bf046e28f6ed434b319028e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([4.8511567, 4.3735776], dtype=float32)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prep = dataset.get_preprocessor()\n",
+    "\n",
+    "tensors = prep(['ACDEM[UNIMOD:35]K', 'PEPTIDEK'])   # raw sequences -> tensors\n",
+    "predictions = model.predict(tensors, verbose=0)\n",
+    "predictions.ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {},
+   "source": [
+    "**Option B — `InferencePipeline`.** Bundle the model with its preprocessor and predict on\n",
+    "raw inputs in one call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:08:38.504514Z",
+     "iopub.status.busy": "2026-06-19T18:08:38.504420Z",
+     "iopub.status.idle": "2026-06-19T18:08:38.573136Z",
+     "shell.execute_reply": "2026-06-19T18:08:38.572845Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4877c69a10814639a07acdc5968604bb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e52131e2f12a49d092554570eb10173e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf3fc8e3b0f64e89bd7231362e9ef9aa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "28c1f11c8f584826aa2aba30c5cea58f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 0s 25ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([4.8511567, 4.3735776], dtype=float32)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipeline = InferencePipeline.from_model_and_dataset(model, dataset)\n",
+    "pipeline.predict(['ACDEM[UNIMOD:35]K', 'PEPTIDEK']).ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {},
+   "source": [
+    "## 3. Save the bundle for later / sharing\n",
+    "\n",
+    "One directory holds the preprocessor, model, and metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:08:38.574595Z",
+     "iopub.status.busy": "2026-06-19T18:08:38.574514Z",
+     "iopub.status.idle": "2026-06-19T18:08:38.612685Z",
+     "shell.execute_reply": "2026-06-19T18:08:38.612410Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'artifacts/rt_model'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipeline.save('artifacts/rt_model', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-11",
+   "metadata": {},
+   "source": [
+    "## 4. Inference-only — load and predict, no training, no dataset\n",
+    "\n",
+    "Imagine a **fresh Python session**: only the saved artifact is needed. `load` restores the\n",
+    "model + preprocessor and checks they match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/Omar/Documents/VSCode_repos/dlomix/dlomix/src/dlomix/data/processing/processors.py:377: UserWarning: The unknown token 'X' is already present in the provided alphabet with index 1. If you prefer the default behavior, consider removing it from the alphabet and it will have the default index of 1.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1cabc4a4466a418ea7c0c59d169847d5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2edb5cd0bc74bf3819eadb249cb0cc1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "55895cf929a048ecb4f38c07c33692b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d75da87913e8495cbd575946d7320934",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 560ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([4.2983775, 4.8189893, 5.3660126], dtype=float32)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipeline2 = InferencePipeline.load('artifacts/rt_model')\n",
+    "pipeline2.predict(['ACDEFGHIK', 'MKLVAAR', 'PEPK']).ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "## 5. Input formats & the standalone preprocessor\n",
+    "\n",
+    "`predict`/`transform` accept a single string, a list/numpy array, a dict that also carries\n",
+    "`model_features` (e.g. `collision_energy`), a pandas DataFrame, or a HuggingFace `Dataset`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:08:39.836809Z",
+     "iopub.status.busy": "2026-06-19T18:08:39.836718Z",
+     "iopub.status.idle": "2026-06-19T18:08:39.940016Z",
+     "shell.execute_reply": "2026-06-19T18:08:39.939720Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6695c86d41b24a1292b8e919175df545",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cbb64c96736b4803956d5682ecd4bfbc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9b2e5ebacada43b593d008f03d3cf3de",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ea3d95e993f243c996a0386efb834ae2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5c39a1d161e14465b83057001b4dbe0c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "acff7a3445e24a28834038f502d0b64a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "13e2783766d849c0804ac363bf37ac23",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d5da3e983c34a3ab14b592961f49b1b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/2 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1529eb07e2b64eb4bd48976146df1f28",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3324e91484364d01b50401212caf9d8d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "39f677281f704742be13e7511fb64285",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "11380b9cc62945859257303869d56927",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ok\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "prep('ACDEFGHIK')                                   # single string\n",
+    "prep(np.array(['ACDEFGHIK', 'PEPK']))               # numpy array\n",
+    "prep(pd.DataFrame({'modified_sequence': ['PEPK']})) # DataFrame\n",
+    "# prep({'modified_sequence': [...], 'collision_energy': [...]})  # dict with model features\n",
+    "print('ok')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "The preprocessor can also live on its own — rebuilt from a saved dataset directory, or\n",
+    "saved/loaded as a small standalone artifact to ship next to a model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:08:39.941477Z",
+     "iopub.status.busy": "2026-06-19T18:08:39.941397Z",
+     "iopub.status.idle": "2026-06-19T18:08:39.977446Z",
+     "shell.execute_reply": "2026-06-19T18:08:39.977217Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4076feb46a7b44c1a6f40d09084cb6fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3972c7c20494889b6e25a95844dfd1b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7ae6ba243c51469ca8965f1812fc1c1c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b14d745fe8ff432585d8d42d63e382dc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/1 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<_PrefetchDataset element_spec=TensorSpec(shape=(None, 22), dtype=tf.int64, name=None)>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# from a dataset saved via dataset.save_to_disk(...)\n",
+    "# prep = PeptidePreprocessor.from_saved('processed_datasets/rt_dataset')\n",
+    "\n",
+    "prep.save('artifacts/rt_preprocessor')\n",
+    "prep = PeptidePreprocessor.load('artifacts/rt_preprocessor')\n",
+    "prep(['PEPTIDEK'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-17",
+   "metadata": {},
+   "source": [
+    "## 6. Share on the HuggingFace Hub\n",
+    "\n",
+    "The bundle is a self-contained folder, so pushing it to the Hub is one call — model,\n",
+    "preprocessor, metadata, and an auto-generated model card travel together. Loading anywhere\n",
+    "is then `from_pretrained`, no training or dataset needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-18",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'omsh/test-model'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# requires HF auth once: `huggingface-cli login`\n",
+    "\n",
+    "# push the bundle to a Hub repo\n",
+    "model_hub_id = \"omsh/test-model\"\n",
+    "pipeline2.push_to_hub(model_hub_id, private=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a56a076-12fe-4993-ac99-8d738b632435",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3adb8e1a822949dcb208594d825cd112",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (incomplete total...): 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "11c0366e7b494d76910fa76bdbba0647",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 5 files:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dc3179598c5b427dada5d38348e013aa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4baa4bc9f53843058a39a584ebf3e6ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fdfc7edd821b43c4bb2008493adb1cd5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d852c476ae7142a7adf4ee7b6ab33ea2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map:   0%|          | 0/3 [00:00<?, ? examples/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 530ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([4.2983775, 4.8189893, 5.3660126], dtype=float32)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# load it back anywhere — no training, no dataset, just the repo id\n",
+    "reloaded = InferencePipeline.from_pretrained(model_hub_id)\n",
+    "reloaded.predict(['ACDEFGHIK', 'MKLVAAR', 'PEPK']).ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-19",
+   "metadata": {},
+   "source": [
+    "**Notes**\n",
+    "\n",
+    "- On construct/load, the pipeline checks the model's embedding size matches the alphabet and\n",
+    "  raises on mismatch — guarding against pairing the wrong model and preprocessor.\n",
+    "- Custom *callable* feature extractors can't be serialized: kept by `get_preprocessor()`,\n",
+    "  dropped by `save()`/`from_saved()` with a warning. Built-in feature names always restore.\n",
+    "- A pipeline must be loaded under the same `DLOMIX_BACKEND` it was saved with."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Example_Inference_Intensity_ModelFeatures.ipynb
+++ b/notebooks/Example_Inference_Intensity_ModelFeatures.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Fragment Ion Intensity \u2014 Inference with Model Features\n",
+    "\n",
+    "Predicting fragment ion intensities with a `PrositIntensityPredictor`. This model takes\n",
+    "**metadata features alongside the sequence** (`precursor_charge_onehot`,\n",
+    "`collision_energy_aligned_normed`), so those must be supplied at inference time too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:24.526662Z",
+     "iopub.status.busy": "2026-06-19T18:41:24.526357Z",
+     "iopub.status.idle": "2026-06-19T18:41:30.254895Z",
+     "shell.execute_reply": "2026-06-19T18:41:30.254594Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow Backend for DLOmix. To change the backend, set the DLOMIX_BACKEND environment variable to tensorflow or pytorch and re-import DLOmix.\n",
+      "\n",
+      "Available feature extractors are (use the key of the following dict and pass it to features_to_extract in the Dataset Class):\n",
+      "{\n",
+      "   \"atom_count\": \"Atom count of PTM.\",\n",
+      "   \"delta_mass\": \"Delta mass of PTM.\",\n",
+      "   \"mod_gain\": \"Gain of atoms due to PTM.\",\n",
+      "   \"mod_loss\": \"Loss of atoms due to PTM.\",\n",
+      "   \"red_smiles\": \"Reduced SMILES representation of PTM.\"\n",
+      "}.\n",
+      "When writing your own feature extractor, you can either\n",
+      "    (1) use the FeatureExtractor class or\n",
+      "    (2) write a function that can be mapped to the Hugging Face dataset.\n",
+      "In both cases, you can access the parsed sequence information from the dataset using the following keys, which all provide python lists:\n",
+      "    - _parsed_sequence: parsed sequence\n",
+      "    - _n_term_mods: N-terminal modifications\n",
+      "    - _c_term_mods: C-terminal modifications\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from datasets import Dataset\n",
+    "\n",
+    "from dlomix.data import FragmentIonIntensityDataset\n",
+    "from dlomix.models import PrositIntensityPredictor\n",
+    "from dlomix.losses import masked_spectral_distance\n",
+    "from dlomix.pipelines import InferencePipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## 1. Data + a trained model (mocked)\n",
+    "\n",
+    "Replace with your data and real training. Here we use the bundled sample and a 1-epoch fit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:30.256693Z",
+     "iopub.status.busy": "2026-06-19T18:41:30.256497Z",
+     "iopub.status.idle": "2026-06-19T18:41:30.284297Z",
+     "shell.execute_reply": "2026-06-19T18:41:30.284045Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>modified_sequence</th>\n",
+       "      <th>precursor_charge_onehot</th>\n",
+       "      <th>collision_energy_aligned_normed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EPPVIC[UNIMOD:4]SHFAQDLWPEQGREDSFQK</td>\n",
+       "      <td>[0, 0, 1, 0, 0, 0]</td>\n",
+       "      <td>0.253658</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>M[UNIMOD:35]VGNVTGAQAYASTTK</td>\n",
+       "      <td>[0, 1, 0, 0, 0, 0]</td>\n",
+       "      <td>0.225589</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>NMMAAC[UNIMOD:4]DPRHGC[UNIMOD:4]YLTVAAIFR</td>\n",
+       "      <td>[0, 0, 0, 1, 0, 0]</td>\n",
+       "      <td>0.322733</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           modified_sequence precursor_charge_onehot  \\\n",
+       "0        EPPVIC[UNIMOD:4]SHFAQDLWPEQGREDSFQK      [0, 0, 1, 0, 0, 0]   \n",
+       "1                M[UNIMOD:35]VGNVTGAQAYASTTK      [0, 1, 0, 0, 0, 0]   \n",
+       "2  NMMAAC[UNIMOD:4]DPRHGC[UNIMOD:4]YLTVAAIFR      [0, 0, 0, 1, 0, 0]   \n",
+       "\n",
+       "   collision_energy_aligned_normed  \n",
+       "0                         0.253658  \n",
+       "1                         0.225589  \n",
+       "2                         0.322733  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# the small sample shipped with the repo (run from repo root or notebooks/)\n",
+    "DATA = next(p for p in [\n",
+    "    'example_dataset/intensity/third_pool_processed_sample.parquet',\n",
+    "    '../example_dataset/intensity/third_pool_processed_sample.parquet',\n",
+    "] if Path(p).exists())\n",
+    "\n",
+    "df = pd.read_parquet(DATA).head(256)   # subset for a fast example\n",
+    "df[['modified_sequence', 'precursor_charge_onehot', 'collision_energy_aligned_normed']].head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:30.285679Z",
+     "iopub.status.busy": "2026-06-19T18:41:30.285583Z",
+     "iopub.status.idle": "2026-06-19T18:41:38.594938Z",
+     "shell.execute_reply": "2026-06-19T18:41:38.594612Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<keras.src.callbacks.History at 0x3b253e990>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = FragmentIonIntensityDataset(\n",
+    "    data_source=Dataset.from_pandas(df, preserve_index=False),\n",
+    "    data_format='hf',\n",
+    "    sequence_column='modified_sequence',\n",
+    "    label_column='intensities_raw',\n",
+    "    model_features=['precursor_charge_onehot', 'collision_energy_aligned_normed'],\n",
+    "    max_seq_len=30,\n",
+    "    batch_size=16,\n",
+    "    val_ratio=0.2,\n",
+    ")\n",
+    "\n",
+    "model = PrositIntensityPredictor(\n",
+    "    seq_length=30,\n",
+    "    input_keys={'SEQUENCE_KEY': 'modified_sequence'},\n",
+    "    meta_data_keys={\n",
+    "        'COLLISION_ENERGY_KEY': 'collision_energy_aligned_normed',\n",
+    "        'PRECURSOR_CHARGE_KEY': 'precursor_charge_onehot',\n",
+    "    },\n",
+    "    use_meta_data=True,\n",
+    "    alphabet=dataset.extended_alphabet,\n",
+    ")\n",
+    "model.compile(optimizer='adam', loss=masked_spectral_distance)\n",
+    "model.fit(dataset.tensor_train_data, epochs=1, verbose=0)  # mock training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "## 2. Inference on raw inputs\n",
+    "\n",
+    "Because the model uses metadata, the inputs are a **dict**: sequences plus the same feature\n",
+    "columns. The preprocessor handles encoding/padding and assembles the model's tensor dict."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:38.596567Z",
+     "iopub.status.busy": "2026-06-19T18:41:38.596468Z",
+     "iopub.status.idle": "2026-06-19T18:41:39.676732Z",
+     "shell.execute_reply": "2026-06-19T18:41:39.676470Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 1s/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_inputs = {\n",
+    "    'modified_sequence': df['modified_sequence'].tolist()[:5],\n",
+    "    'precursor_charge_onehot': [list(x) for x in df['precursor_charge_onehot'][:5]],\n",
+    "    'collision_energy_aligned_normed': df['collision_energy_aligned_normed'].tolist()[:5],\n",
+    "}\n",
+    "\n",
+    "pipeline = InferencePipeline.from_model_and_dataset(model, dataset)\n",
+    "predictions = pipeline.predict(raw_inputs)\n",
+    "predictions.shape   # (n_peptides, n_fragment_ions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-07",
+   "metadata": {},
+   "source": [
+    "## 3. Save / load locally\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:39.678211Z",
+     "iopub.status.busy": "2026-06-19T18:41:39.678138Z",
+     "iopub.status.idle": "2026-06-19T18:41:41.424909Z",
+     "shell.execute_reply": "2026-06-19T18:41:41.424641Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 791ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipeline.save('artifacts/intensity_model', overwrite=True)\n",
+    "reloaded = InferencePipeline.load('artifacts/intensity_model')\n",
+    "reloaded.predict(raw_inputs).shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {},
+   "source": [
+    "## 4. Share on the HuggingFace Hub\n",
+    "\n",
+    "The bundle (model + preprocessor + metadata) is pushed as one repo and loaded back with\n",
+    "`from_pretrained` \u2014 no training or dataset needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:41:41.426357Z",
+     "iopub.status.busy": "2026-06-19T18:41:41.426282Z",
+     "iopub.status.idle": "2026-06-19T18:42:02.105426Z",
+     "shell.execute_reply": "2026-06-19T18:42:02.105193Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 667ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# requires HF auth once: `huggingface-cli login`\n",
+    "pipeline.push_to_hub('omsh/test-model', private=True)\n",
+    "\n",
+    "reloaded = InferencePipeline.from_pretrained('omsh/test-model')\n",
+    "reloaded.predict(raw_inputs).shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-11",
+   "metadata": {},
+   "source": [
+    "**Notes**\n",
+    "\n",
+    "- Metadata models need their `model_features` provided at inference \u2014 missing columns raise a\n",
+    "  clear error.\n",
+    "- This pushes to the shared `omsh/test-model` repo and **overwrites** its contents."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/Example_Inference_Intensity_PTMFeatures.ipynb
+++ b/notebooks/Example_Inference_Intensity_PTMFeatures.ipynb
@@ -1,0 +1,432 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Fragment Ion Intensity \u2014 Inference with PTM Features\n",
+    "\n",
+    "Same model family, but with **PTM features** (`mod_loss`, `delta_mass`) and `naive-mods`\n",
+    "encoding. Unlike `model_features`, PTM features are **computed from the sequence** by the\n",
+    "preprocessor \u2014 you still only pass sequences (+ metadata) at inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:21.265166Z",
+     "iopub.status.busy": "2026-06-19T18:52:21.264897Z",
+     "iopub.status.idle": "2026-06-19T18:52:26.770280Z",
+     "shell.execute_reply": "2026-06-19T18:52:26.769870Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using TensorFlow Backend for DLOmix. To change the backend, set the DLOMIX_BACKEND environment variable to tensorflow or pytorch and re-import DLOmix.\n",
+      "\n",
+      "Available feature extractors are (use the key of the following dict and pass it to features_to_extract in the Dataset Class):\n",
+      "{\n",
+      "   \"atom_count\": \"Atom count of PTM.\",\n",
+      "   \"delta_mass\": \"Delta mass of PTM.\",\n",
+      "   \"mod_gain\": \"Gain of atoms due to PTM.\",\n",
+      "   \"mod_loss\": \"Loss of atoms due to PTM.\",\n",
+      "   \"red_smiles\": \"Reduced SMILES representation of PTM.\"\n",
+      "}.\n",
+      "When writing your own feature extractor, you can either\n",
+      "    (1) use the FeatureExtractor class or\n",
+      "    (2) write a function that can be mapped to the Hugging Face dataset.\n",
+      "In both cases, you can access the parsed sequence information from the dataset using the following keys, which all provide python lists:\n",
+      "    - _parsed_sequence: parsed sequence\n",
+      "    - _n_term_mods: N-terminal modifications\n",
+      "    - _c_term_mods: C-terminal modifications\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from datasets import Dataset\n",
+    "\n",
+    "from dlomix.data import FragmentIonIntensityDataset\n",
+    "from dlomix.models import PrositIntensityPredictor\n",
+    "from dlomix.losses import masked_spectral_distance\n",
+    "from dlomix.pipelines import InferencePipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## 1. Data + a trained model (mocked)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:26.772390Z",
+     "iopub.status.busy": "2026-06-19T18:52:26.772143Z",
+     "iopub.status.idle": "2026-06-19T18:52:26.784406Z",
+     "shell.execute_reply": "2026-06-19T18:52:26.784122Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>modified_sequence</th>\n",
+       "      <th>precursor_charge_onehot</th>\n",
+       "      <th>collision_energy_aligned_normed</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>EPPVIC[UNIMOD:4]SHFAQDLWPEQGREDSFQK</td>\n",
+       "      <td>[0, 0, 1, 0, 0, 0]</td>\n",
+       "      <td>0.253658</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>M[UNIMOD:35]VGNVTGAQAYASTTK</td>\n",
+       "      <td>[0, 1, 0, 0, 0, 0]</td>\n",
+       "      <td>0.225589</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>NMMAAC[UNIMOD:4]DPRHGC[UNIMOD:4]YLTVAAIFR</td>\n",
+       "      <td>[0, 0, 0, 1, 0, 0]</td>\n",
+       "      <td>0.322733</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           modified_sequence precursor_charge_onehot  \\\n",
+       "0        EPPVIC[UNIMOD:4]SHFAQDLWPEQGREDSFQK      [0, 0, 1, 0, 0, 0]   \n",
+       "1                M[UNIMOD:35]VGNVTGAQAYASTTK      [0, 1, 0, 0, 0, 0]   \n",
+       "2  NMMAAC[UNIMOD:4]DPRHGC[UNIMOD:4]YLTVAAIFR      [0, 0, 0, 1, 0, 0]   \n",
+       "\n",
+       "   collision_energy_aligned_normed  \n",
+       "0                         0.253658  \n",
+       "1                         0.225589  \n",
+       "2                         0.322733  "
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "# the small sample shipped with the repo (run from repo root or notebooks/)\n",
+    "DATA = next(p for p in [\n",
+    "    'example_dataset/intensity/third_pool_processed_sample.parquet',\n",
+    "    '../example_dataset/intensity/third_pool_processed_sample.parquet',\n",
+    "] if Path(p).exists())\n",
+    "\n",
+    "df = pd.read_parquet(DATA).head(256)   # subset for a fast example\n",
+    "df[['modified_sequence', 'precursor_charge_onehot', 'collision_energy_aligned_normed']].head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:26.785761Z",
+     "iopub.status.busy": "2026-06-19T18:52:26.785667Z",
+     "iopub.status.idle": "2026-06-19T18:52:35.947769Z",
+     "shell.execute_reply": "2026-06-19T18:52:35.947480Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<keras.src.callbacks.History at 0x35075c6d0>"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset = FragmentIonIntensityDataset(\n",
+    "    data_source=Dataset.from_pandas(df, preserve_index=False),\n",
+    "    data_format='hf',\n",
+    "    sequence_column='modified_sequence',\n",
+    "    label_column='intensities_raw',\n",
+    "    model_features=['collision_energy_aligned_normed', 'precursor_charge_onehot'],\n",
+    "    features_to_extract=['mod_loss', 'delta_mass'],   # computed from the sequence\n",
+    "    encoding_scheme='naive-mods',\n",
+    "    max_seq_len=30,\n",
+    "    batch_size=16,\n",
+    "    val_ratio=0.2,\n",
+    ")\n",
+    "\n",
+    "model = PrositIntensityPredictor(\n",
+    "    seq_length=30,\n",
+    "    use_prosit_ptm_features=True,\n",
+    "    use_meta_data=True,\n",
+    "    input_keys={'SEQUENCE_KEY': 'modified_sequence'},\n",
+    "    meta_data_keys={\n",
+    "        'COLLISION_ENERGY_KEY': 'collision_energy_aligned_normed',\n",
+    "        'PRECURSOR_CHARGE_KEY': 'precursor_charge_onehot',\n",
+    "    },\n",
+    "    alphabet=dataset.extended_alphabet,\n",
+    ")\n",
+    "model.compile(optimizer='adam', loss=masked_spectral_distance)\n",
+    "model.fit(dataset.tensor_train_data, epochs=1, verbose=0)  # mock training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-05",
+   "metadata": {},
+   "source": [
+    "## 2. Inference on raw inputs\n",
+    "\n",
+    "The preprocessor recomputes `mod_loss` / `delta_mass` from each sequence, so the inputs are\n",
+    "just sequences plus the metadata features \u2014 the PTM features are never supplied by hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:35.949328Z",
+     "iopub.status.busy": "2026-06-19T18:52:35.949234Z",
+     "iopub.status.idle": "2026-06-19T18:52:35.952193Z",
+     "shell.execute_reply": "2026-06-19T18:52:35.951942Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['modified_sequence',\n",
+       " 'collision_energy_aligned_normed',\n",
+       " 'precursor_charge_onehot',\n",
+       " 'mod_loss',\n",
+       " 'delta_mass']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "raw_inputs = {\n",
+    "    'modified_sequence': df['modified_sequence'].tolist()[:5],\n",
+    "    'collision_energy_aligned_normed': df['collision_energy_aligned_normed'].tolist()[:5],\n",
+    "    'precursor_charge_onehot': [list(x) for x in df['precursor_charge_onehot'][:5]],\n",
+    "}\n",
+    "\n",
+    "pipeline = InferencePipeline.from_model_and_dataset(model, dataset)\n",
+    "pipeline.preprocessor.input_columns   # note mod_loss / delta_mass are added automatically"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:35.953537Z",
+     "iopub.status.busy": "2026-06-19T18:52:35.953443Z",
+     "iopub.status.idle": "2026-06-19T18:52:36.827604Z",
+     "shell.execute_reply": "2026-06-19T18:52:36.827293Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 795ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predictions = pipeline.predict(raw_inputs)\n",
+    "predictions.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "## 3. Save / load locally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:36.829045Z",
+     "iopub.status.busy": "2026-06-19T18:52:36.828969Z",
+     "iopub.status.idle": "2026-06-19T18:52:38.843336Z",
+     "shell.execute_reply": "2026-06-19T18:52:38.843037Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 769ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pipeline.save('artifacts/intensity_ptm_model', overwrite=True)\n",
+    "reloaded = InferencePipeline.load('artifacts/intensity_ptm_model')\n",
+    "reloaded.predict(raw_inputs).shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5cfb3ac5",
+   "metadata": {},
+   "source": [
+    "## 4. Share on the HuggingFace Hub\n",
+    "\n",
+    "The bundle (model + preprocessor + metadata) is pushed as one repo and loaded back with\n",
+    "`from_pretrained` \u2014 no training or dataset needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-19T18:52:38.844791Z",
+     "iopub.status.busy": "2026-06-19T18:52:38.844719Z",
+     "iopub.status.idle": "2026-06-19T18:52:56.364796Z",
+     "shell.execute_reply": "2026-06-19T18:52:56.364532Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/1 [==============================] - 1s 690ms/step\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, 174)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# requires HF auth once: `huggingface-cli login`\n",
+    "pipeline.push_to_hub('omsh/test-model', private=True)\n",
+    "\n",
+    "reloaded = InferencePipeline.from_pretrained('omsh/test-model')\n",
+    "reloaded.predict(raw_inputs).shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "**Notes**\n",
+    "\n",
+    "- PTM features (`mod_loss`, `delta_mass`) are reproduced by the preprocessor; only built-in\n",
+    "  (string) feature names survive `save()` / Hub round-trips \u2014 custom callables do not.\n",
+    "- This pushes to the shared `omsh/test-model` repo and **overwrites** its contents."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/run_scripts/run_prosit_chargestate_distribution.py
+++ b/run_scripts/run_prosit_chargestate_distribution.py
@@ -23,6 +23,7 @@ d = ChargeStateDataset(
     label_column="charge_state_dist",
     max_seq_len=30,
     batch_size=8,
+    val_ratio=0.2,
 )
 print(d)
 for x in d.tensor_train_data:
@@ -64,7 +65,7 @@ history = model.fit(
     callbacks=callbacks,
 )
 
-predictions = model.predict(test_sequences)
+predictions = model.predict(test_d.tensor_test_data)
 predictions = predictions
 
 print("first 5 test sequences:\n", test_sequences[:5])

--- a/run_scripts/run_prosit_chargestate_distribution_torch.py
+++ b/run_scripts/run_prosit_chargestate_distribution_torch.py
@@ -25,6 +25,8 @@ d = ChargeStateDataset(
     max_seq_len=30,
     batch_size=8,
     dataset_type="pt",
+    val_ratio=0.2,
+    with_termini=False,
 )
 print(d)
 for x in d.tensor_train_data:
@@ -39,6 +41,7 @@ test_d = ChargeStateDataset(
     max_seq_len=30,
     batch_size=8,
     dataset_type="pt",
+    with_termini=False,
 )
 
 

--- a/run_scripts/run_prosit_chargestate_dominant.py
+++ b/run_scripts/run_prosit_chargestate_dominant.py
@@ -1,5 +1,6 @@
 import numpy as np
 import tensorflow as tf
+from datasets import load_dataset
 
 from dlomix.constants import PTMS_ALPHABET
 from dlomix.data import ChargeStateDataset
@@ -16,13 +17,18 @@ optimizer = tf.keras.optimizers.Adam(lr=0.0001)
 
 TESTING_DATA = "example_dataset/chargestate/chargestate_data.parquet"
 
+hf_charge_dataset = load_dataset("Wilhelmlab/prospect-ptms-charge", split="val")
+
 d = ChargeStateDataset(
-    data_format="parquet",  # "hub",
-    data_source=TESTING_DATA,  # "Wilhelmlab/prospect-ptms-charge",
+    data_format="hf",
+    data_source=hf_charge_dataset,
     sequence_column="modified_sequence",
     label_column="most_abundant_charge_state",
     max_seq_len=30,
     batch_size=8,
+    val_ratio=0.2,
+    split_strategy="stratified",
+    stratify_by_column="most_abundant_charge_state",
 )
 print(d)
 for x in d.tensor_train_data:
@@ -65,7 +71,7 @@ history = model.fit(
     callbacks=callbacks,
 )
 
-predictions = model.predict(test_sequences)
+predictions = model.predict(test_d.tensor_test_data)
 # this returns the index (== the charge state -1) of the predicted most abundant charge state
 predicted_class = np.argmax(predictions, axis=1)
 

--- a/run_scripts/run_prosit_chargestate_observed.py
+++ b/run_scripts/run_prosit_chargestate_observed.py
@@ -22,6 +22,8 @@ d = ChargeStateDataset(
     label_column="observed_charge_states",
     max_seq_len=30,
     batch_size=8,
+    val_ratio=0.2,
+    split_strategy="sequence-unique",
 )
 print(d)
 for x in d.tensor_train_data:
@@ -62,7 +64,7 @@ history = model.fit(
     callbacks=callbacks,
 )
 
-predictions = model.predict(test_sequences)
+predictions = model.predict(test_d.tensor_test_data)
 
 print("first 5 test sequences:\n", test_sequences[:5])
 print("first 5 test observed charge state vectors (label):\n", test_targets[:5])

--- a/run_scripts/run_prosit_retentiontime.py
+++ b/run_scripts/run_prosit_retentiontime.py
@@ -67,11 +67,11 @@ test_d = RetentionTimeDataset(
 test_targets = test_d["test"]["irt"]
 test_sequences = test_d["test"]["sequence"]
 
-predictions = model.predict(test_sequences)
+predictions = model.predict(test_d.tensor_test_data)
 predictions = predictions.ravel()
 
 train_sequences = d["train"]["sequence"]
-train_predictions = model.predict(train_sequences)
+train_predictions = model.predict(d.tensor_train_data)
 train_predictions = train_predictions.ravel()
 
 print(train_sequences[:5])

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
     python_requires=">=3.10",
     install_requires=[
         "datasets>=4.0.0",
-        "huggingface_hub",
+        "huggingface_hub>=0.20.0",
         "fpdf",
         "pandas",
         "numpy",

--- a/src/dlomix/data/__init__.py
+++ b/src/dlomix/data/__init__.py
@@ -1,10 +1,12 @@
 from .charge_state import ChargeStateDataset
-from .dataset import PeptideDataset, load_processed_dataset
+from .dataset import PeptideDataset
 from .dataset_splitter import SplitConfig, SplitStrategy, create_splitter
 from .detectability import DetectabilityDataset
 from .fragment_ion_intensity import FragmentIonIntensityDataset
 from .ion_mobility import IonMobilityDataset
+from .processing.feature_extractors import available_feature_extractors
 from .retention_time import RetentionTimeDataset
+from .serialization import load_processed_dataset
 
 __all__ = [
     "RetentionTimeDataset",
@@ -17,4 +19,5 @@ __all__ = [
     "SplitConfig",
     "SplitStrategy",
     "create_splitter",
+    "available_feature_extractors",
 ]

--- a/src/dlomix/data/__init__.py
+++ b/src/dlomix/data/__init__.py
@@ -1,5 +1,6 @@
 from .charge_state import ChargeStateDataset
 from .dataset import PeptideDataset, load_processed_dataset
+from .dataset_splitter import SplitConfig, SplitStrategy, create_splitter
 from .detectability import DetectabilityDataset
 from .fragment_ion_intensity import FragmentIonIntensityDataset
 from .ion_mobility import IonMobilityDataset
@@ -13,4 +14,7 @@ __all__ = [
     "load_processed_dataset",
     "DetectabilityDataset",
     "IonMobilityDataset",
+    "SplitConfig",
+    "SplitStrategy",
+    "create_splitter",
 ]

--- a/src/dlomix/data/__init__.py
+++ b/src/dlomix/data/__init__.py
@@ -3,6 +3,7 @@ from .dataset import PeptideDataset
 from .dataset_splitter import SplitConfig, SplitStrategy, create_splitter
 from .detectability import DetectabilityDataset
 from .fragment_ion_intensity import FragmentIonIntensityDataset
+from .inference import PeptidePreprocessor
 from .ion_mobility import IonMobilityDataset
 from .processing.feature_extractors import available_feature_extractors
 from .retention_time import RetentionTimeDataset
@@ -19,5 +20,6 @@ __all__ = [
     "SplitConfig",
     "SplitStrategy",
     "create_splitter",
+    "PeptidePreprocessor",
     "available_feature_extractors",
 ]

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -36,6 +36,11 @@ class ChargeStateDataset(PeptideDataset):
         num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
+        split_strategy (Optional[str]): Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'. Default is 'random'.
+        split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
+        test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
+        stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
+        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -66,6 +71,11 @@ class ChargeStateDataset(PeptideDataset):
         num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
+        split_strategy: Optional[str] = "random",
+        split_seed: Optional[int] = None,
+        test_ratio: Optional[float] = None,
+        stratify_by_column: Optional[str] = None,
+        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -16,7 +16,7 @@ class ChargeStateDataset(PeptideDataset):
         data_format (str): The format of the data source file(s). Default is "parquet".
         sequence_column (str): The name of the column containing the peptide sequences. Default is "modified_sequence".
         label_column (str): The name of the column containing the charge state labels. Default is "most_abundant_charge_by_count".
-        val_ratio (float): The ratio of validation data to split from the training data. Default is 0.2.
+        val_ratio (Optional[float]): Fraction of data for the validation split. None or 0 means no val split. Default None.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences. Default is 30.
         dataset_type (str): The type of dataset to use. Default is "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation. Default is 256.
@@ -50,7 +50,7 @@ class ChargeStateDataset(PeptideDataset):
         data_format: str = "parquet",
         sequence_column: str = "modified_sequence",
         label_column: str = "most_abundant_charge_by_count",
-        val_ratio: float = 0.2,
+        val_ratio: Optional[float] = None,
         max_seq_len: Union[int, str] = 30,
         dataset_type: str = "tf",
         batch_size: int = 256,

--- a/src/dlomix/data/charge_state.py
+++ b/src/dlomix/data/charge_state.py
@@ -40,7 +40,6 @@ class ChargeStateDataset(PeptideDataset):
         split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
         test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
         stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
-        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -75,7 +74,6 @@ class ChargeStateDataset(PeptideDataset):
         split_seed: Optional[int] = None,
         test_ratio: Optional[float] = None,
         stratify_by_column: Optional[str] = None,
-        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -3,12 +3,14 @@ import json
 import logging
 import os
 import warnings
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from datasets import Dataset, DatasetDict, Sequence, Value, load_dataset
 
 from .dataset_config import DatasetConfig
+from .dataset_splitter import SplitConfig, create_splitter
 from .dataset_utils import EncodingScheme, get_num_processors, resolve_num_proc
 from .processing.feature_extractors import (
     AVAILABLE_FEATURE_EXTRACTORS,
@@ -25,6 +27,12 @@ from .processing.processors import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _DatasetSplitMode(Enum):
+    AUTO = "auto"  # Single train source; run the configured splitter
+    PREDEFINED = "predefined"  # Splits defined externally; pass through as-is
+    TEST_ONLY = "test_only"  # Only a test set provided; no splitting needed
 
 
 class PeptideDataset:
@@ -144,8 +152,7 @@ class PeptideDataset:
         if not self.processed:
             self.hf_dataset: Optional[Union[Dataset, DatasetDict]] = None
             self._empty_dataset_mode = False
-            self._is_predefined_split = False
-            self._test_set_only = False
+            self._split_mode: Optional[_DatasetSplitMode] = None
             self._num_proc = dataset_config.num_proc
             self._set_num_proc()
 
@@ -217,7 +224,6 @@ class PeptideDataset:
     def _load_from_hub(self):
         self.hf_dataset = load_dataset(self.data_source, **self._kwargs)
         self._empty_dataset_mode = False
-        self._is_predefined_split = True
         warnings.warn(
             'The provided data is assumed to be hosted on the Hugging Face Hub since data_format is set to "hub". Validation and test data sources will be ignored.'
         )
@@ -241,14 +247,13 @@ class PeptideDataset:
 
     def _load_from_inmemory_hf_dataset(self):
         self._empty_dataset_mode = False
-        self._is_predefined_split = True
+
         warnings.warn(
-            f'The provided data is assumed to be an in-memory Hugging Face Dataset or DatasetDict object since data_format is set to "hf". Validation and test data sources will be ignored and the split names of the DatasetDict has to follow the default namings {PeptideDataset.DEFAULT_SPLIT_NAMES}.'
+            f'The provided data is assumed to be an in-memory Hugging Face Dataset or DatasetDict object since data_format is set to "hf". Validation and test data sources will be ignored and the split names of the DatasetDict has to follow the default namings {PeptideDataset.DEFAULT_SPLIT_NAMES}. If a Dataset is provided it will be split according to the split configuration provided by the user.'
         )
 
         if isinstance(self.data_source, DatasetDict):
             self.hf_dataset = self.data_source
-            self._data_files_available_splits = dict.fromkeys(self.hf_dataset)
             self._data_files_available_splits = {
                 split: f"in-memory Dataset object - {split}"
                 for split in self.hf_dataset
@@ -265,30 +270,54 @@ class PeptideDataset:
                 "The provided data source is not a valid Hugging Face Dataset/DatasetDict object. The data_format value should be set to 'hf' if you plan to use an in-memory Hugging Face Dataset/DatasetDict object."
             )
 
+    def _has_explicit_split_params(self) -> bool:
+        return (
+            self.test_ratio is not None
+            or (self.split_strategy and self.split_strategy.lower() != "random")
+            or self.split_seed is not None
+            or self.stratify_by_column is not None
+        )
+
+    def _determine_split_mode(self) -> _DatasetSplitMode:
+        """Determine how splitting should be handled based on loaded data and format."""
+        # Hub datasets are always predefined: trust the hub's split structure
+        if self.data_format == "hub":
+            return _DatasetSplitMode.PREDEFINED
+
+        # In-memory DatasetDict is predefined by definition
+        if self.data_format == "hf" and isinstance(self.data_source, DatasetDict):
+            return _DatasetSplitMode.PREDEFINED
+
+        available = self._data_files_available_splits
+
+        # Multiple sources provided → all splits are already defined externally
+        if len(available) >= 2:
+            return _DatasetSplitMode.PREDEFINED
+
+        # Single source: determine which split it represents
+        if PeptideDataset.DEFAULT_SPLIT_NAMES[2] in available:  # "test" only
+            return _DatasetSplitMode.TEST_ONLY
+
+        if PeptideDataset.DEFAULT_SPLIT_NAMES[1] in available:  # "val" only, no train
+            return _DatasetSplitMode.PREDEFINED
+
+        # Single "train" source (file or in-memory Dataset) → auto-split
+        return _DatasetSplitMode.AUTO
+
     def _decide_on_splitting(self):
-        count_loaded_data_sources = len(self._data_files_available_splits)
+        self._split_mode = self._determine_split_mode()
 
-        # one data source provided -> if test, then test only, if val, then do not split
-        if count_loaded_data_sources == 1:
-            if (
-                self.test_data_source is not None
-                or PeptideDataset.DEFAULT_SPLIT_NAMES[2]
-                in self._data_files_available_splits
-            ):
-                # test data source provided OR hugging face dataset with test split only
-                self._test_set_only = True
-            if self.val_data_source is not None:
-                self._is_predefined_split = True
-
-        # two or more data sources provided -> no splitting in all cases
-        if count_loaded_data_sources >= 2:
-            self._is_predefined_split = True
-
-        if self._is_predefined_split:
-            warnings.warn(f"""
-                Multiple data sources or a single non-train data source provided {self._data_files_available_splits}, please ensure that the data sources are already split into train, val and test sets
-                since no splitting will happen. If not, please provide only one data_source and set the val_ratio to split the data into train and val sets."
-                """)
+        if (
+            self._split_mode == _DatasetSplitMode.PREDEFINED
+            and self._has_explicit_split_params()
+        ):
+            raise ValueError(
+                f"Cannot use split configuration parameters (split_strategy, split_seed, "
+                f"test_ratio, stratify_by_column) when providing predefined data sources. "
+                f"Found predefined splits: {self._data_files_available_splits}. "
+                f"Either provide only data_source for automatic splitting or provide predefined "
+                f"splits without split configuration parameters."
+            )
 
     def _remove_unnecessary_columns(self):
         self._relevant_columns = [self.sequence_column, *self.label_column]
@@ -304,21 +333,46 @@ class PeptideDataset:
         self.hf_dataset = self.hf_dataset.select_columns(self._relevant_columns)
 
     def _split_dataset(self):
-        if self._is_predefined_split or self._test_set_only:
+        if self._split_mode != _DatasetSplitMode.AUTO:
             return
 
-        # only a train dataset or a train and a test but no val -> split train into train/val
+        assert isinstance(self.hf_dataset, DatasetDict)
 
-        splitted_dataset = self.hf_dataset[
-            PeptideDataset.DEFAULT_SPLIT_NAMES[0]
-        ].train_test_split(test_size=self.val_ratio)
+        # Validate stratify_by_column if provided
+        stratify_column = self.stratify_by_column
+        if stratify_column is not None:
+            train_columns = self.hf_dataset[
+                PeptideDataset.DEFAULT_SPLIT_NAMES[0]
+            ].column_names
+            if (
+                stratify_column not in self.label_column
+                and stratify_column not in train_columns
+            ):
+                raise ValueError(
+                    f"Stratification column '{stratify_column}' not found in dataset. "
+                    f"Available columns: {train_columns}"
+                )
 
-        self.hf_dataset["train"] = splitted_dataset["train"]
-        self.hf_dataset["val"] = splitted_dataset["test"]
+        split_config = SplitConfig(
+            val_ratio=self.val_ratio,
+            test_ratio=self.test_ratio,
+            strategy=self.split_strategy if self.split_strategy else "random",
+            seed=self.split_seed,
+            stratify_column=stratify_column,
+            sequence_column=self.sequence_column,
+            test_uniqueness=self.test_uniqueness,
+        )
 
-        del splitted_dataset["train"]
-        del splitted_dataset["test"]
-        del splitted_dataset
+        splitter = create_splitter(split_config)
+        logger.info(
+            "Splitting dataset using %s strategy with config: %s",
+            split_config.strategy.value,
+            split_config,
+        )
+
+        self.hf_dataset = splitter.split(
+            self.hf_dataset[PeptideDataset.DEFAULT_SPLIT_NAMES[0]]
+        )
 
     def _parse_sequences(self):
         # parse sequence in all encoding schemes

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -643,7 +643,7 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
         state = {}
 
         # Add all runtime attributes (computed during processing)
-        exclude = {"hf_dataset", "_config", "data_source", "_processors"}
+        exclude = {"hf_dataset", "_config", "data_source", "_processors", "_split_mode"}
 
         for key, value in self.__dict__.items():
             if key in exclude:

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -1,38 +1,22 @@
-import importlib
-import json
 import logging
-import os
 import warnings
-from enum import Enum
-from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Optional, Union
 
-from datasets import Dataset, DatasetDict, Sequence, Value, load_dataset
+from datasets import Dataset, DatasetDict
 
 from .dataset_config import DatasetConfig
 from .dataset_splitter import SplitConfig, create_splitter
 from .dataset_utils import EncodingScheme, get_num_processors, resolve_num_proc
-from .processing.feature_extractors import (
-    AVAILABLE_FEATURE_EXTRACTORS,
-    FEATURE_EXTRACTORS_PARAMETERS,
-    LookupFeatureExtractor,
-)
-from .processing.processors import (
-    FunctionProcessor,
-    PeptideDatasetBaseProcessor,
-    SequenceEncodingProcessor,
-    SequencePaddingProcessor,
-    SequenceParsingProcessor,
-    SequencePTMRemovalProcessor,
+from .loading import DataSourceLoader, _DatasetSplitMode
+from .processing.pipeline import PipelineContext, ProcessingPipeline
+from .serialization import save_dataset
+from .tensor_conversion import (
+    cast_feature_columns_to_float,
+    to_tf_tensor_dataset,
+    to_torch_dataloader,
 )
 
 logger = logging.getLogger(__name__)
-
-
-class _DatasetSplitMode(Enum):
-    AUTO = "auto"  # Single train source; run the configured splitter
-    PREDEFINED = "predefined"  # Splits defined externally; pass through as-is
-    TEST_ONLY = "test_only"  # Only a test set provided; no splitting needed
 
 
 class PeptideDataset:
@@ -150,27 +134,24 @@ class PeptideDataset:
         # explcit assignments of processed attribute
         self.processed = dataset_config.processed
         if not self.processed:
-            self.hf_dataset: Optional[Union[Dataset, DatasetDict]] = None
-            self._empty_dataset_mode = False
-            self._split_mode: Optional[_DatasetSplitMode] = None
             self._num_proc = dataset_config.num_proc
             self._set_num_proc()
 
-            self._data_files_available_splits = {}
-            self._load_dataset()
-            self._decide_on_splitting()
+            load_result = DataSourceLoader(dataset_config, self._kwargs).load()
+            self.hf_dataset: Optional[Union[Dataset, DatasetDict]] = (
+                load_result.hf_dataset
+            )
+            self._data_files_available_splits = load_result.available_splits
+            self._empty_dataset_mode = load_result.empty
+            self._split_mode: Optional[_DatasetSplitMode] = load_result.split_mode
 
             self._relevant_columns = []
             self._extracted_features_columns = []
 
             if not self._empty_dataset_mode:
-                self._processors = []
                 self._remove_unnecessary_columns()
                 self._split_dataset()
-                self._parse_sequences()
-
-                self._configure_processing_pipeline()
-                self._apply_processing_pipeline()
+                self._run_processing_pipeline()
                 if (
                     self.model_features is not None
                     or len(self._extracted_features_columns) > 0
@@ -193,164 +174,6 @@ class PeptideDataset:
             from datasets import disable_caching
 
             disable_caching()
-
-    def _load_dataset(self):
-        if self.data_format == "hub":
-            self._load_from_hub()
-            return
-
-        if self.data_format == "hf":
-            self._load_from_inmemory_hf_dataset()
-            return
-
-        data_sources = [self.data_source, self.val_data_source, self.test_data_source]
-
-        for split_name, source in zip(PeptideDataset.DEFAULT_SPLIT_NAMES, data_sources):
-            if source is not None:
-                self._data_files_available_splits[split_name] = source
-
-        if len(self._data_files_available_splits) == 0:
-            self._empty_dataset_mode = True
-            warnings.warn(
-                "No data files provided, please provide at least one data source if you plan to use this dataset directly. Otherwise, you can later load data into this empty dataset"
-            )
-        else:
-            self._empty_dataset_mode = False
-
-            self.hf_dataset = load_dataset(
-                self.data_format, data_files=self._data_files_available_splits
-            )
-
-    def _load_from_hub(self):
-        self.hf_dataset = load_dataset(self.data_source, **self._kwargs)
-        self._empty_dataset_mode = False
-        warnings.warn(
-            'The provided data is assumed to be hosted on the Hugging Face Hub since data_format is set to "hub". Validation and test data sources will be ignored.'
-        )
-        if isinstance(self.hf_dataset, DatasetDict):
-            for split in self.hf_dataset.keys():
-                if split not in PeptideDataset.DEFAULT_SPLIT_NAMES:
-                    raise ValueError(
-                        f"The split name {split} is not a valid split name. Please use one of the default split names: {PeptideDataset.DEFAULT_SPLIT_NAMES}."
-                    )
-            self._data_files_available_splits = {
-                split: f"HF hub dataset - {self.data_source} - {split}"
-                for split in self.hf_dataset
-            }
-
-        else:
-            self._data_files_available_splits = {
-                PeptideDataset.DEFAULT_SPLIT_NAMES[
-                    0
-                ]: f"HF hub dataset - {self.data_source}"
-            }
-
-    def _load_from_inmemory_hf_dataset(self):
-        self._empty_dataset_mode = False
-
-        if isinstance(self.data_source, DatasetDict):
-            warnings.warn(
-                'data_format="hf" with a DatasetDict: using the provided splits as-is. '
-                f"Split names must follow {PeptideDataset.DEFAULT_SPLIT_NAMES}. "
-                "val_data_source and test_data_source are ignored."
-            )
-            self.hf_dataset = self.data_source
-            self._data_files_available_splits = {
-                split: f"in-memory Dataset object - {split}"
-                for split in self.hf_dataset
-            }
-
-        elif isinstance(self.data_source, Dataset):
-            warnings.warn(
-                'data_format="hf" with a Dataset: the dataset will be automatically split '
-                "into train/val (and optionally test) according to the split configuration. "
-                "val_data_source and test_data_source are ignored."
-            )
-            self.hf_dataset = DatasetDict()
-            self.hf_dataset[PeptideDataset.DEFAULT_SPLIT_NAMES[0]] = self.data_source
-            self._data_files_available_splits = {
-                PeptideDataset.DEFAULT_SPLIT_NAMES[0]: "in-memory Dataset object"
-            }
-        else:
-            raise ValueError(
-                "The provided data source is not a valid Hugging Face Dataset/DatasetDict object. The data_format value should be set to 'hf' if you plan to use an in-memory Hugging Face Dataset/DatasetDict object."
-            )
-
-    def _has_explicit_split_params(self) -> bool:
-        return (
-            self.val_ratio is not None
-            or self.test_ratio is not None
-            or (self.split_strategy and self.split_strategy.lower() != "random")
-            or self.stratify_by_column is not None
-        )
-
-    def _determine_split_mode(self) -> _DatasetSplitMode:
-        """Determine how splitting should be handled based on loaded data and format."""
-        # Hub datasets are always predefined: trust the hub's split structure
-        if self.data_format == "hub":
-            return _DatasetSplitMode.PREDEFINED
-
-        # In-memory DatasetDict is predefined by definition
-        if self.data_format == "hf" and isinstance(self.data_source, DatasetDict):
-            return _DatasetSplitMode.PREDEFINED
-
-        available = self._data_files_available_splits
-
-        # Multiple sources provided → all splits are already defined externally
-        if len(available) >= 2:
-            return _DatasetSplitMode.PREDEFINED
-
-        # Single source: determine which split it represents
-        if PeptideDataset.DEFAULT_SPLIT_NAMES[2] in available:  # "test" only
-            return _DatasetSplitMode.TEST_ONLY
-
-        if PeptideDataset.DEFAULT_SPLIT_NAMES[1] in available:  # "val" only, no train
-            return _DatasetSplitMode.PREDEFINED
-
-        # Single "train" source (file or in-memory Dataset) → auto-split
-        return _DatasetSplitMode.AUTO
-
-    def _decide_on_splitting(self):
-        self._split_mode = self._determine_split_mode()
-
-        if self._split_mode == _DatasetSplitMode.PREDEFINED:
-            warnings.warn(
-                f"Using provided splits as-is: {list(self._data_files_available_splits.keys())}. "
-                "No automatic splitting will occur."
-            )
-        elif self._split_mode == _DatasetSplitMode.TEST_ONLY:
-            warnings.warn(
-                "Only a test split was provided. No automatic splitting will occur."
-            )
-
-        if self._split_mode != _DatasetSplitMode.AUTO and self.split_seed is not None:
-            warnings.warn(
-                f"split_seed={self.split_seed} is set but no automatic splitting will occur "
-                f"(splits are predefined or only a test set was provided). The seed is ignored."
-            )
-
-        if (
-            self._split_mode == _DatasetSplitMode.PREDEFINED
-            and self._has_explicit_split_params()
-        ):
-            raise ValueError(
-                f"Cannot use split configuration parameters (val_ratio, test_ratio, "
-                f"split_strategy, stratify_by_column) when providing predefined data sources. "
-                f"Found predefined splits: {list(self._data_files_available_splits.keys())}. "
-                f"Either provide only data_source for automatic splitting or provide predefined "
-                f"splits without split configuration parameters."
-            )
-
-        if (
-            self._split_mode == _DatasetSplitMode.TEST_ONLY
-            and self._has_explicit_split_params()
-        ):
-            raise ValueError(
-                "Cannot use split configuration parameters (val_ratio, test_ratio, "
-                "split_strategy, stratify_by_column) when only test data is provided — "
-                "there is no training data to split. "
-                "Either omit the split parameters or also provide data_source."
-            )
 
     def _remove_unnecessary_columns(self):
         self._relevant_columns = [self.sequence_column, *self.label_column]
@@ -380,8 +203,20 @@ class PeptideDataset:
 
         assert isinstance(self.hf_dataset, DatasetDict)
 
-        # Validate stratify_by_column if provided
         stratify_column = self.stratify_by_column
+
+        # Require stratify_by_column for stratified splitting (dataset-facing name;
+        # SplitConfig would otherwise raise using its own 'stratify_column' parameter).
+        if (
+            self.split_strategy
+            and self.split_strategy.lower() == "stratified"
+            and stratify_column is None
+        ):
+            raise ValueError(
+                "stratify_by_column must be provided when split_strategy='stratified'."
+            )
+
+        # Validate stratify_by_column exists in the data if provided
         if stratify_column is not None:
             train_columns = self.hf_dataset[
                 PeptideDataset.DEFAULT_SPLIT_NAMES[0]
@@ -405,12 +240,6 @@ class PeptideDataset:
         )
 
         splitter = create_splitter(split_config)
-        logger.info(
-            "Splitting dataset using %s strategy with config: %s",
-            split_config.strategy.value,
-            split_config,
-        )
-
         self.hf_dataset = splitter.split(
             self.hf_dataset[PeptideDataset.DEFAULT_SPLIT_NAMES[0]]
         )
@@ -421,253 +250,44 @@ class PeptideDataset:
             self._relevant_columns.remove(self._temp_stratify_column)
             self._temp_stratify_column = None
 
-    def _parse_sequences(self):
-        # parse sequence in all encoding schemes
-        sequence_parsing_processor = SequenceParsingProcessor(
-            self.sequence_column,
-            batched=True,
+    def _run_processing_pipeline(self):
+        pipeline = ProcessingPipeline.from_config(
+            sequence_column=self.sequence_column,
+            encoding_scheme=self.encoding_scheme,
             with_termini=self.with_termini,
+            max_seq_len=self.max_seq_len,
+            padding_value=self.padding_value,
+            alphabet=self.extended_alphabet,
+            learning_alphabet_mode=self.learning_alphabet_mode,
+            pad=self.pad,
+            features_to_extract=self.features_to_extract,
+            split_names=PeptideDataset.DEFAULT_SPLIT_NAMES,
         )
 
-        self.dataset_columns_to_keep.extend(
-            SequenceParsingProcessor.PARSED_COL_NAMES.values()
-        )
-        self._processors.append(sequence_parsing_processor)
+        # parsed columns are kept in the HF dataset but not returned as tensors
+        self.dataset_columns_to_keep.extend(pipeline.parsed_columns)
+        self._extracted_features_columns = pipeline.extracted_feature_names
 
-        if self.encoding_scheme == EncodingScheme.UNMOD:
-            warnings.warn(
-                f"""Encoding scheme is {self.encoding_scheme}, this enforces removing all occurences of PTMs in the sequences.
-If you prefer to encode the (amino-acids)+PTM combinations as tokens in the vocabulary, please use the encoding scheme 'naive-mods'.
-"""
-            )
-
-            self._processors.append(
-                SequencePTMRemovalProcessor(
-                    sequence_column_name=self.sequence_column, batched=True
-                )
-            )
-
-    def _configure_processing_pipeline(self):
-        self._configure_encoding_step()
-        self._configure_padding_step()
-        self._configure_feature_extraction_step()
-
-    def _configure_encoding_step(self):
-        encoding_processor = None
-
-        if (
-            self.encoding_scheme == EncodingScheme.UNMOD
-            or self.encoding_scheme == EncodingScheme.NAIVE_MODS
-        ):
-            encoding_processor = SequenceEncodingProcessor(
-                sequence_column_name=self.sequence_column,
-                alphabet=self.extended_alphabet,
-                batched=True,
-                extend_alphabet=self.learning_alphabet_mode,
-            )
-        else:
-            raise NotImplementedError(
-                f"Encoding scheme {self.encoding_scheme} is not implemented. Available encoding schemes are: {list(EncodingScheme.__members__)}."
-            )
-
-        self._processors.append(encoding_processor)
-
-    def _configure_padding_step(self):
-        if not self.pad:
-            warnings.warn(
-                "Padding is turned off, sequences will have variable lengths. Converting this dataset to tensors will cause errors unless proper stacking of examples is done."
-            )
-            return
-
-        padding_processor = SequencePaddingProcessor(
-            sequence_column_name=self.sequence_column,
-            batched=True,
-            padding_index=self.extended_alphabet[self.padding_value],
-            max_length=self.max_seq_len + 2 if self.with_termini else self.max_seq_len,
-        )
-
-        self._processors.append(padding_processor)
-
-    def _configure_feature_extraction_step(self):
-        if self.features_to_extract is None or len(self.features_to_extract) == 0:
-            return
-
-        for feature in self.features_to_extract:
-            if isinstance(feature, str):
-                feature_name = feature.lower()
-
-                if feature_name not in AVAILABLE_FEATURE_EXTRACTORS:
-                    warnings.warn(
-                        f"Skipping feature extractor {feature} since it is not available. Please choose from the available feature extractors: {AVAILABLE_FEATURE_EXTRACTORS}."
-                    )
-                    continue
-
-                # We pass here the parsed sequence to the feature extractor since it will always be a list with AA+PTM as elements
-                feature_extactor = LookupFeatureExtractor(
-                    sequence_column_name=SequenceParsingProcessor.PARSED_COL_NAMES[
-                        "seq"
-                    ],
-                    feature_column_name=feature_name,
-                    **FEATURE_EXTRACTORS_PARAMETERS[feature_name],
-                    max_length=(
-                        self.max_seq_len + 2 if self.with_termini else self.max_seq_len
-                    ),
-                    batched=True,
-                )
-            elif isinstance(feature, Callable):
-                warnings.warn(
-                    (
-                        f"Using custom feature extractor from the user function {feature.__name__}"
-                        "please ensure that the provided function pads the feature to the sequence length"
-                        "so that all tensors have the same sequence length dimension."
-                    )
-                )
-
-                feature_name = feature.__name__
-                feature_extactor = FunctionProcessor(feature)
-            else:
-                raise ValueError(
-                    f"Feature extractor {feature} is not a valid type. Please provide a function or a string that is a valid feature extractor name."
-                )
-
-            self._extracted_features_columns.append(feature_name)
-            self._processors.append(feature_extactor)
-
-    def _apply_processing_pipeline(self):
-        for processor in self._processors:
-            split_order = self._get_split_processing_order(processor)
-            for split in split_order:
-                logger.info(
-                    "Applying step: %s on split %s...",
-                    processor.__class__.__name__,
-                    split,
-                )
-
-                logger.debug(
-                    "Applying step with arguments:\n\n %s on split %s", processor, split
-                )
-
-                # split-specific logic for encoding
-                if isinstance(processor, SequenceEncodingProcessor):
-                    if split in PeptideDataset.DEFAULT_SPLIT_NAMES[0:2]:
-                        # train/val split -> learn the alphabet unless otherwise specified
-                        # force single processor to ensure that the alphabet is learned on the entire split and not just on a subset of the data when using multi-processing
-
-                        strictly_single_process = bool(
-                            getattr(processor, "extend_alphabet", False)
-                            or getattr(processor, "learning_alphabet_mode", False)
-                        )
-
-                        self._apply_processor_to_split(
-                            processor,
-                            split,
-                            force_single_processor=strictly_single_process,
-                        )
-
-                        self.extended_alphabet = processor.alphabet.copy()
-
-                    elif split == PeptideDataset.DEFAULT_SPLIT_NAMES[2]:
-                        # test split -> use the learned alphabet from the train/val split
-                        # and enable fallback to encoding unseen (AA, PTM) as unmodified Amino acids
-                        temp_test_processor = SequenceEncodingProcessor(
-                            sequence_column_name=self.sequence_column,
-                            alphabet=self.extended_alphabet,
-                            batched=True,
-                            extend_alphabet=False,
-                            fallback_unmodified=True,
-                        )
-
-                        self._apply_processor_to_split(temp_test_processor, split)
-
-                    else:
-                        raise Warning(
-                            f"When applying processors, found split '{split}' which is not a valid split name. Please use one of the default split names: {PeptideDataset.DEFAULT_SPLIT_NAMES} to ensure correct behavior."
-                        )
-                else:
-                    # --------------------------------------------------------------------
-                    # split-agnostic logic -> run processor for all splits
-                    self._apply_processor_to_split(processor, split)
-                    # --------------------------------------------------------------------
-
-                # split-specific logic for truncating train/val sequences only after padding
-                if isinstance(processor, SequencePaddingProcessor):
-                    if split != PeptideDataset.DEFAULT_SPLIT_NAMES[2]:
-                        logger.info("Removing truncated sequences in the %s ", split)
-
-                        self.hf_dataset[split] = self.hf_dataset[split].filter(
-                            lambda batch: batch[processor.KEEP_COLUMN_NAME],
-                            batched=True,
-                            num_proc=self._num_proc,
-                            batch_size=self.batch_processing_size,
-                        )
-
-                logger.info("Done with step: %s \n", processor.__class__.__name__)
-
-        self.hf_dataset = self.hf_dataset.remove_columns(
-            SequencePaddingProcessor.KEEP_COLUMN_NAME
-        )
-
-    def _get_split_processing_order(self, processor: PeptideDatasetBaseProcessor):
-        split_order = list(self.hf_dataset.keys())
-
-        # Ensure encoding sees train/val before test so test uses full learned vocab.
-        if isinstance(processor, SequenceEncodingProcessor):
-            ordered_default = [
-                split
-                for split in PeptideDataset.DEFAULT_SPLIT_NAMES
-                if split in self.hf_dataset
-            ]
-            non_default = [
-                split for split in split_order if split not in ordered_default
-            ]
-            return ordered_default + non_default
-
-        return split_order
-
-    def _apply_processor_to_split(
-        self,
-        processor: PeptideDatasetBaseProcessor,
-        split: str,
-        force_single_processor: bool = False,
-    ):
-        extra_meta_data = ""
-        if isinstance(processor, FunctionProcessor):
-            extra_meta_data = f" (function name: {processor.function.__name__})"
-
-        self.hf_dataset[split] = self.hf_dataset[split].map(
-            processor,
-            desc=f"Mapping {processor.__class__.__name__} {extra_meta_data} on split {split}",
-            batched=processor.batched,
+        ctx = PipelineContext(
+            alphabet=self.extended_alphabet,
+            num_proc=self._num_proc,
             batch_size=self.batch_processing_size,
-            num_proc=None if force_single_processor else self._num_proc,
+            fit_splits=tuple(PeptideDataset.DEFAULT_SPLIT_NAMES[0:2]),
         )
+        self.hf_dataset = pipeline.apply(self.hf_dataset, ctx)
+        # the encoding processor learns/extends the alphabet during the run
+        self.extended_alphabet = ctx.alphabet
 
     def _cast_model_feature_types_to_float(self):
-        def cast_to_float(feature):
-            """Recursively casts Sequence and Value features to float32."""
-            if isinstance(feature, Sequence):
-                # Recursively apply the transformation to the nested feature
-                return Sequence(cast_to_float(feature.feature))
-            if isinstance(feature, Value):
-                return Value("float32")
-            return feature  # Return as is for unsupported feature types
-
         features_to_cast = set().union(
             self.model_features or [],
             self._extracted_features_columns or [],
         )
 
         for split in self.hf_dataset.keys():
-            new_features = self.hf_dataset[split].features.copy()
-
-            for feature_name, feature_type in self.hf_dataset[split].features.items():
-                # Ensure model features are casted to float for concatenation later
-                if feature_name not in features_to_cast:
-                    continue
-                new_features[feature_name] = cast_to_float(feature_type)
-
-            self.hf_dataset[split] = self.hf_dataset[split].cast(
-                new_features,
+            self.hf_dataset[split] = cast_feature_columns_to_float(
+                self.hf_dataset[split],
+                features_to_cast,
                 num_proc=self._num_proc,
                 batch_size=self.batch_processing_size,
             )
@@ -677,119 +297,9 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
             cleaned_up = self.hf_dataset.cleanup_cache_files()
             logger.info("Cleaned up cache files: %s.", cleaned_up)
 
-    def _get_serializable_state(self) -> Dict[str, Any]:
-        """
-        Extract all state needed to reconstruct the object.
-
-        Returns
-        -------
-        Dict[str, Any]
-            Complete object state.
-        """
-        # Start with original config parameters
-        state = {}
-
-        # Add all runtime attributes (computed during processing)
-        exclude = {
-            "hf_dataset",
-            "_config",
-            "data_source",
-            "_processors",
-            "_split_mode",
-            "_temp_stratify_column",
-        }
-
-        for key, value in self.__dict__.items():
-            if key in exclude:
-                continue
-            # Only serialize JSON-compatible types
-            try:
-                json.dumps(value)
-                state[key] = value
-            except:
-                # For complex objects, store just the type
-                if isinstance(value, dict):
-                    state[key] = value
-                elif isinstance(value, (list, tuple, set)):
-                    state[key] = list(value)
-                else:
-                    state[key] = str(type(value))
-
-        return state
-
-    def save_to_disk(self, path: str, overwrite: bool = False):
-        """
-        Save the dataset to disk.
-
-        Parameters
-        ----------
-        path : str
-            Path to save the dataset to.
-        overwrite : bool, optional
-            Whether to overwrite existing directory, by default False.
-
-        """
-
-        path_obj = Path(path)
-
-        # Check if path exists
-        if path_obj.exists() and not overwrite:
-            raise FileExistsError(
-                f"Directory {path} already exists. Set overwrite=True to overwrite and replace the saved dataset."
-            )
-
-        # Create directory
-        path_obj.mkdir(parents=True, exist_ok=True)
-
-        # 1. Save the ORIGINAL config (input parameters only)
-        # No refresh needed - config represents what user provided
-        self._config.save_config_json(os.path.join(path, self.CONFIG_JSON_NAME))
-
-        # 2. Save the complete object state (metadata)
-        state = self._get_serializable_state()
-        metadata = {
-            "class_name": self.__class__.__name__,
-            "module_name": self.__class__.__module__,
-            "state": state,
-            "version": PeptideDataset.SERIALIZATION_VERSION,  # Version for serialization format
-        }
-
-        with open(path_obj / self.METADATA_JSON_NAME, "w") as f:
-            json.dump(metadata, f, indent=2)
-
-        # 3. Save the HuggingFace dataset
-        if self.hf_dataset is not None:
-            self.hf_dataset.save_to_disk(str(path_obj / "hf_dataset"))
-
-        return True
-
-    def _validate_loaded_state(self):
-        """
-        Validate that the loaded state is consistent.
-
-        Raises
-        ------
-        ValueError
-            If the state is inconsistent.
-        """
-        # Check that essential attributes exist
-        if not hasattr(self, "hf_dataset") or self.hf_dataset is None:
-            raise ValueError("HuggingFace dataset not loaded properly.")
-
-        if not self.processed:
-            raise ValueError("Dataset should be marked as processed after loading.")
-
-        # Validate that dataset columns match expected columns
-        if hasattr(self, "_relevant_columns"):
-            for split in self.hf_dataset.keys():
-                dataset_columns = set(self.hf_dataset[split].column_names)
-                expected_columns = set(self._relevant_columns)
-
-                if not expected_columns.issubset(dataset_columns):
-                    missing = expected_columns - dataset_columns
-                    raise ValueError(
-                        f"Split '{split}' is missing expected columns: {missing}"
-                    )
+    def save_to_disk(self, path: str, overwrite: bool = False) -> bool:
+        """Save the dataset (config, runtime state, and HF data) to ``path``."""
+        return save_dataset(self, path, overwrite)
 
     @classmethod
     def from_dataset_config(cls, config: DatasetConfig):
@@ -876,6 +386,17 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
 
             return tf_dataset
 
+    def get_preprocessor(self):
+        """Return a :class:`PeptidePreprocessor` capturing this dataset's recipe.
+
+        The preprocessor reproduces the exact training-time preprocessing (alphabet,
+        encoding, padding, feature extractors) and can be applied to raw inputs for
+        inference, or bundled with a model. See :mod:`dlomix.data.inference`.
+        """
+        from .inference import PeptidePreprocessor
+
+        return PeptidePreprocessor.from_dataset(self)
+
     def _check_if_split_exists(self, split_name: str):
         existing_splits = list(self.hf_dataset.keys())
         if split_name not in existing_splits:
@@ -887,125 +408,33 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
     def _get_split_tf_dataset(self, split_name: str):
         self._check_if_split_exists(split_name)
 
-        # to return a tuple if it is a single label column and be compatible with HF Datasets API updates
-
-        label_cols = self.label_column
-
-        if isinstance(self.label_column, list) and len(self.label_column) == 1:
-            label_cols = self.label_column[0]
-
-        return self.hf_dataset[split_name].to_tf_dataset(
-            columns=self._get_input_tensor_column_names(),
-            label_cols=label_cols,
+        return to_tf_tensor_dataset(
+            self.hf_dataset[split_name],
+            input_columns=self._get_input_tensor_column_names(),
+            batch_size=self.batch_size,
+            label_cols=self.label_column,
             shuffle=(
                 self.shuffle
                 if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
                 else False
             ),
-            batch_size=self.batch_size,
         )
 
     def _get_split_torch_dataset(self, split_name: str):
         self._check_if_split_exists(split_name)
 
-        from torch.utils.data import DataLoader
-
-        # Prepare DataLoader kwargs, starting with defaults
-        dataloader_kwargs = {
-            "dataset": self.hf_dataset[split_name].with_format(
-                type="torch",
-                columns=[*self._get_input_tensor_column_names(), *self.label_column],
-            ),
-            "batch_size": self.batch_size,
-            "shuffle": (
+        return to_torch_dataloader(
+            self.hf_dataset[split_name],
+            input_columns=self._get_input_tensor_column_names(),
+            batch_size=self.batch_size,
+            label_cols=self.label_column,
+            shuffle=(
                 self.shuffle
                 if split_name == PeptideDataset.DEFAULT_SPLIT_NAMES[0]
                 else False
             ),
-        }
-
-        # Update with user-provided torch_dataloader_kwargs if available
-        if hasattr(self, "torch_dataloader_kwargs") and self.torch_dataloader_kwargs:
-            # Don't override the dataset parameter
-            user_kwargs = {
-                k: v for k, v in self.torch_dataloader_kwargs.items() if k != "dataset"
-            }
-            dataloader_kwargs.update(user_kwargs)
-
-        data_loader = DataLoader(**dataloader_kwargs)
-
-        return data_loader
-
-
-# ------------------------------------------------------------------------------------------------
-
-
-def load_processed_dataset(path: str, validate: bool = True):
-    """
-    Load a processed peptide dataset from a given path.
-
-    Parameters
-    ----------
-    path : str
-        Path to the peptide dataset.
-    validate : bool, optional
-        Whether to validate the loaded dataset state, by default True.
-
-    Returns
-    -------
-    dlomix.data.PeptideDataset or one of its child classes
-        Peptide dataset.
-    """
-
-    path_obj = Path(path)
-
-    if not path_obj.exists():
-        raise FileNotFoundError(
-            f"Provided directory for loading the dataset: {path} does not exist."
+            dataloader_kwargs=getattr(self, "torch_dataloader_kwargs", None),
         )
 
-    # 1. Load the config
-    config = DatasetConfig.load_config_json(
-        str(path_obj / PeptideDataset.CONFIG_JSON_NAME)
-    )
 
-    # 2. Load metadata
-    metadata_path = path_obj / PeptideDataset.METADATA_JSON_NAME
-    if metadata_path.exists():
-        with open(metadata_path, "r") as f:
-            metadata = json.load(f)
-    else:
-        # Fallback for datasets saved without metadata
-        metadata = None
-
-    # 3. Create instance with processed=True to skip initialization processing
-    module = importlib.import_module("dlomix.data")
-    class_name = (
-        metadata.get("class_name", "PeptideDataset") if metadata else "PeptideDataset"
-    )
-    cls = getattr(module, class_name)
-
-    # ensure processed flag is set in config to avoid re-processing
-    config.processed = True
-
-    instance = cls.from_dataset_config(config)
-    instance._config.processed = False  # Reset config processed flag
-    instance.processed = True  # Ensure processed flag is set
-
-    # 4. Restore state from metadata
-    if metadata:
-        for key, value in metadata["state"].items():
-            setattr(instance, key, value)
-
-    # 5. Load the HuggingFace dataset
-    hf_dataset_path = path_obj / "hf_dataset"
-    if hf_dataset_path.exists():
-        from datasets import load_from_disk
-
-        instance.hf_dataset = load_from_disk(str(hf_dataset_path))
-
-    # 6. Validate if requested
-    if validate:
-        instance._validate_loaded_state()
-
-    return instance
+# ``load_processed_dataset`` lives in serialization.py (exported from ``dlomix.data``).

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -248,11 +248,12 @@ class PeptideDataset:
     def _load_from_inmemory_hf_dataset(self):
         self._empty_dataset_mode = False
 
-        warnings.warn(
-            f'The provided data is assumed to be an in-memory Hugging Face Dataset or DatasetDict object since data_format is set to "hf". Validation and test data sources will be ignored and the split names of the DatasetDict has to follow the default namings {PeptideDataset.DEFAULT_SPLIT_NAMES}. If a Dataset is provided it will be split according to the split configuration provided by the user.'
-        )
-
         if isinstance(self.data_source, DatasetDict):
+            warnings.warn(
+                'data_format="hf" with a DatasetDict: using the provided splits as-is. '
+                f"Split names must follow {PeptideDataset.DEFAULT_SPLIT_NAMES}. "
+                "val_data_source and test_data_source are ignored."
+            )
             self.hf_dataset = self.data_source
             self._data_files_available_splits = {
                 split: f"in-memory Dataset object - {split}"
@@ -260,6 +261,11 @@ class PeptideDataset:
             }
 
         elif isinstance(self.data_source, Dataset):
+            warnings.warn(
+                'data_format="hf" with a Dataset: the dataset will be automatically split '
+                "into train/val (and optionally test) according to the split configuration. "
+                "val_data_source and test_data_source are ignored."
+            )
             self.hf_dataset = DatasetDict()
             self.hf_dataset[PeptideDataset.DEFAULT_SPLIT_NAMES[0]] = self.data_source
             self._data_files_available_splits = {
@@ -272,9 +278,9 @@ class PeptideDataset:
 
     def _has_explicit_split_params(self) -> bool:
         return (
-            self.test_ratio is not None
+            self.val_ratio is not None
+            or self.test_ratio is not None
             or (self.split_strategy and self.split_strategy.lower() != "random")
-            or self.split_seed is not None
             or self.stratify_by_column is not None
         )
 
@@ -307,16 +313,43 @@ class PeptideDataset:
     def _decide_on_splitting(self):
         self._split_mode = self._determine_split_mode()
 
+        if self._split_mode == _DatasetSplitMode.PREDEFINED:
+            warnings.warn(
+                f"Using provided splits as-is: {list(self._data_files_available_splits.keys())}. "
+                "No automatic splitting will occur."
+            )
+        elif self._split_mode == _DatasetSplitMode.TEST_ONLY:
+            warnings.warn(
+                "Only a test split was provided. No automatic splitting will occur."
+            )
+
+        if self._split_mode != _DatasetSplitMode.AUTO and self.split_seed is not None:
+            warnings.warn(
+                f"split_seed={self.split_seed} is set but no automatic splitting will occur "
+                f"(splits are predefined or only a test set was provided). The seed is ignored."
+            )
+
         if (
             self._split_mode == _DatasetSplitMode.PREDEFINED
             and self._has_explicit_split_params()
         ):
             raise ValueError(
-                f"Cannot use split configuration parameters (split_strategy, split_seed, "
-                f"test_ratio, stratify_by_column) when providing predefined data sources. "
-                f"Found predefined splits: {self._data_files_available_splits}. "
+                f"Cannot use split configuration parameters (val_ratio, test_ratio, "
+                f"split_strategy, stratify_by_column) when providing predefined data sources. "
+                f"Found predefined splits: {list(self._data_files_available_splits.keys())}. "
                 f"Either provide only data_source for automatic splitting or provide predefined "
                 f"splits without split configuration parameters."
+            )
+
+        if (
+            self._split_mode == _DatasetSplitMode.TEST_ONLY
+            and self._has_explicit_split_params()
+        ):
+            raise ValueError(
+                "Cannot use split configuration parameters (val_ratio, test_ratio, "
+                "split_strategy, stratify_by_column) when only test data is provided — "
+                "there is no training data to split. "
+                "Either omit the split parameters or also provide data_source."
             )
 
     def _remove_unnecessary_columns(self):

--- a/src/dlomix/data/dataset.py
+++ b/src/dlomix/data/dataset.py
@@ -329,6 +329,15 @@ class PeptideDataset:
             # additional columns to keep in the hugging face dataset only and not return as tensors
             self._relevant_columns.extend(self.dataset_columns_to_keep)
 
+        # Preserve stratify_by_column through splitting; track if it needs removal afterward
+        self._temp_stratify_column: Optional[str] = None
+        if (
+            self.stratify_by_column is not None
+            and self.stratify_by_column not in self._relevant_columns
+        ):
+            self._relevant_columns.append(self.stratify_by_column)
+            self._temp_stratify_column = self.stratify_by_column
+
         # select only relevant columns from the Hugging Face Dataset (includes label column)
         self.hf_dataset = self.hf_dataset.select_columns(self._relevant_columns)
 
@@ -360,7 +369,6 @@ class PeptideDataset:
             seed=self.split_seed,
             stratify_column=stratify_column,
             sequence_column=self.sequence_column,
-            test_uniqueness=self.test_uniqueness,
         )
 
         splitter = create_splitter(split_config)
@@ -373,6 +381,12 @@ class PeptideDataset:
         self.hf_dataset = splitter.split(
             self.hf_dataset[PeptideDataset.DEFAULT_SPLIT_NAMES[0]]
         )
+
+        # Drop the stratify column from all splits if it was only kept temporarily
+        if self._temp_stratify_column is not None:
+            self.hf_dataset = self.hf_dataset.remove_columns(self._temp_stratify_column)
+            self._relevant_columns.remove(self._temp_stratify_column)
+            self._temp_stratify_column = None
 
     def _parse_sequences(self):
         # parse sequence in all encoding schemes
@@ -643,7 +657,14 @@ If you prefer to encode the (amino-acids)+PTM combinations as tokens in the voca
         state = {}
 
         # Add all runtime attributes (computed during processing)
-        exclude = {"hf_dataset", "_config", "data_source", "_processors", "_split_mode"}
+        exclude = {
+            "hf_dataset",
+            "_config",
+            "data_source",
+            "_processors",
+            "_split_mode",
+            "_temp_stratify_column",
+        }
 
         for key, value in self.__dict__.items():
             if key in exclude:
@@ -926,7 +947,9 @@ def load_processed_dataset(path: str, validate: bool = True):
 
     # 3. Create instance with processed=True to skip initialization processing
     module = importlib.import_module("dlomix.data")
-    class_name = metadata.get("class_name") if metadata else "PeptideDataset"
+    class_name = (
+        metadata.get("class_name", "PeptideDataset") if metadata else "PeptideDataset"
+    )
     cls = getattr(module, class_name)
 
     # ensure processed flag is set in config to avoid re-processing

--- a/src/dlomix/data/dataset_config.py
+++ b/src/dlomix/data/dataset_config.py
@@ -13,9 +13,8 @@ class DatasetConfig:
 
     Splitting Parameters
     --------------------
-    val_ratio : float
-        Ratio of validation data (0 < val_ratio < 1). Default is 0.2.
-        Used for automatic splitting when val_data_source is not provided.
+    val_ratio : Optional[float]
+        Fraction of data for the validation split. None or 0 means no val split. Default None.
     split_strategy : Optional[str]
         Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'.
         Default is 'random'. Only used when automatic splitting is performed.
@@ -35,7 +34,6 @@ class DatasetConfig:
     data_format: str
     sequence_column: str
     label_column: List[str]
-    val_ratio: float
     max_seq_len: int
     dataset_type: str
     batch_size: int
@@ -55,7 +53,8 @@ class DatasetConfig:
     num_proc: Optional[int]
     batch_processing_size: int
     torch_dataloader_kwargs: Optional[Dict] = field(default_factory=dict)
-    # New splitting parameters
+    # Splitting parameters
+    val_ratio: Optional[float] = None
     split_strategy: Optional[str] = "random"
     split_seed: Optional[int] = None
     test_ratio: Optional[float] = None

--- a/src/dlomix/data/dataset_config.py
+++ b/src/dlomix/data/dataset_config.py
@@ -27,9 +27,6 @@ class DatasetConfig:
     stratify_by_column : Optional[str]
         Column name for stratified splitting. Can be a label column or any feature column.
         Only used when split_strategy='stratified'. Default is None.
-    test_uniqueness : bool
-        When using split_strategy='sequence_unique', ensures test sequences are unique from
-        train/val. Default is True.
     """
 
     data_source: Union[str, List]
@@ -63,7 +60,6 @@ class DatasetConfig:
     split_seed: Optional[int] = None
     test_ratio: Optional[float] = None
     stratify_by_column: Optional[str] = None
-    test_uniqueness: bool = True
 
     # validate input parameters
     def __post_init__(self):

--- a/src/dlomix/data/dataset_config.py
+++ b/src/dlomix/data/dataset_config.py
@@ -10,6 +10,26 @@ from .dataset_utils import EncodingScheme, validate_num_proc_value
 class DatasetConfig:
     """
     Configuration class for the dataset.
+
+    Splitting Parameters
+    --------------------
+    val_ratio : float
+        Ratio of validation data (0 < val_ratio < 1). Default is 0.2.
+        Used for automatic splitting when val_data_source is not provided.
+    split_strategy : Optional[str]
+        Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'.
+        Default is 'random'. Only used when automatic splitting is performed.
+    split_seed : Optional[int]
+        Random seed for reproducible splits. Default is None.
+    test_ratio : Optional[float]
+        Ratio of test data for three-way splits (0 < test_ratio < 1).
+        If None, only train/val split is performed. Default is None.
+    stratify_by_column : Optional[str]
+        Column name for stratified splitting. Can be a label column or any feature column.
+        Only used when split_strategy='stratified'. Default is None.
+    test_uniqueness : bool
+        When using split_strategy='sequence_unique', ensures test sequences are unique from
+        train/val. Default is True.
     """
 
     data_source: Union[str, List]
@@ -38,6 +58,12 @@ class DatasetConfig:
     num_proc: Optional[int]
     batch_processing_size: int
     torch_dataloader_kwargs: Optional[Dict] = field(default_factory=dict)
+    # New splitting parameters
+    split_strategy: Optional[str] = "random"
+    split_seed: Optional[int] = None
+    test_ratio: Optional[float] = None
+    stratify_by_column: Optional[str] = None
+    test_uniqueness: bool = True
 
     # validate input parameters
     def __post_init__(self):

--- a/src/dlomix/data/dataset_splitter.py
+++ b/src/dlomix/data/dataset_splitter.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
-from datasets import ClassLabel, Dataset, DatasetDict
+from datasets import ClassLabel, Dataset, DatasetDict, Sequence
 
 
 class SplitStrategy(str, Enum):
@@ -196,7 +196,16 @@ class RandomSplitter(DatasetSplitter):
 
 
 class StratifiedSplitter(DatasetSplitter):
-    """Splits dataset while preserving the class distribution of a given column."""
+    """Splits dataset while preserving the class distribution of a given column.
+
+    HF's ``train_test_split`` needs a scalar categorical key. A ``ClassLabel`` column is
+    used directly, a scalar ``Value`` column is class-encoded, and a list/one-hot column
+    is stratified on its *exact value* (each distinct vector becomes one stratum — for
+    one-hot labels this is equivalent to stratifying by class) via a temporary key that is
+    dropped after splitting.
+    """
+
+    STRATIFY_KEY_COLUMN = "_stratify_key"
 
     def split(self, dataset: Dataset) -> DatasetDict:
         if self.config.stratify_column not in dataset.column_names:
@@ -205,41 +214,85 @@ class StratifiedSplitter(DatasetSplitter):
                 f"Available columns: {dataset.column_names}"
             )
 
-        # HF train_test_split requires ClassLabel feature type for stratification.
-        # Auto-cast if the column is a plain Value type so users don't need to do this manually.
-        if not isinstance(dataset.features[self.config.stratify_column], ClassLabel):
-            warnings.warn(
-                f"Stratification column '{self.config.stratify_column}' is not ClassLabel type "
-                f"(got {dataset.features[self.config.stratify_column]}). "
-                f"Auto-casting to ClassLabel for stratified splitting."
-            )
-            dataset = dataset.class_encode_column(self.config.stratify_column)
+        dataset, strat, temp_key = self._resolve_stratify_column(dataset)
 
         val, test = self.config.val_ratio, self.config.test_ratio
-        strat = self.config.stratify_column
-        if val and test:
-            return self._perform_three_way_split(
-                dataset,
-                val_size=val,
-                test_size=test,
-                seed=self.config.seed,
-                stratify_by_column=strat,
+        try:
+            if val and test:
+                result = self._perform_three_way_split(
+                    dataset,
+                    val_size=val,
+                    test_size=test,
+                    seed=self.config.seed,
+                    stratify_by_column=strat,
+                )
+            elif val:
+                result = self._perform_two_way_split(
+                    dataset,
+                    ratio=val,
+                    second_name="val",
+                    seed=self.config.seed,
+                    stratify_by_column=strat,
+                )
+            else:
+                assert test is not None
+                result = self._perform_two_way_split(
+                    dataset,
+                    ratio=test,
+                    second_name="test",
+                    seed=self.config.seed,
+                    stratify_by_column=strat,
+                )
+        except ValueError as exc:
+            if "least populated" in str(exc) or "member" in str(exc):
+                raise ValueError(
+                    f"Stratified split failed: column '{self.config.stratify_column}' has "
+                    "a class with too few members (each class needs at least 2 to be split). "
+                    "Use a column with fewer/larger classes, gather more data, or switch to "
+                    "split_strategy='random'."
+                ) from exc
+            raise
+
+        if temp_key is not None:
+            result = result.remove_columns(temp_key)
+        return result
+
+    def _resolve_stratify_column(self, dataset: Dataset):
+        """Return ``(dataset, stratify_column_name, temp_key_column_or_None)``.
+
+        Produces a scalar categorical column suitable for HF stratification.
+        """
+        column = self.config.stratify_column
+        assert column is not None  # guaranteed by SplitConfig + split() validation
+        feature = dataset.features[column]
+
+        if isinstance(feature, ClassLabel):
+            return dataset, column, None
+
+        # list / one-hot / vector column: stratify on the exact value via a derived key
+        if isinstance(feature, (Sequence, list)):
+            warnings.warn(
+                f"Stratification column '{column}' is a list/vector column; stratifying on "
+                "its exact value (each distinct vector is treated as one class — for one-hot "
+                "labels this stratifies by class). A temporary key column is used and dropped "
+                "after splitting."
             )
-        if val:
-            return self._perform_two_way_split(
-                dataset,
-                ratio=val,
-                second_name="val",
-                seed=self.config.seed,
-                stratify_by_column=strat,
+            dataset = dataset.map(
+                lambda batch: {
+                    self.STRATIFY_KEY_COLUMN: [str(v) for v in batch[column]]
+                },
+                batched=True,
             )
-        return self._perform_two_way_split(
-            dataset,
-            ratio=test,
-            second_name="test",
-            seed=self.config.seed,  # type: ignore[arg-type]
-            stratify_by_column=strat,
+            dataset = dataset.class_encode_column(self.STRATIFY_KEY_COLUMN)
+            return dataset, self.STRATIFY_KEY_COLUMN, self.STRATIFY_KEY_COLUMN
+
+        # scalar Value column: encode in place
+        warnings.warn(
+            f"Stratification column '{column}' is not ClassLabel type (got {feature}). "
+            "Auto-casting to ClassLabel for stratified splitting."
         )
+        dataset = dataset.class_encode_column(column)
+        return dataset, column, None
 
 
 class SequenceUniqueSplitter(DatasetSplitter):

--- a/src/dlomix/data/dataset_splitter.py
+++ b/src/dlomix/data/dataset_splitter.py
@@ -1,21 +1,18 @@
 """
 Dataset splitting strategies for peptide datasets.
 
-This module provides a flexible and extensible framework for splitting datasets
-using various strategies including random, sequence-based uniqueness, and stratified
-splitting.
+Provides random, stratified, and sequence-unique splitting via a common interface.
 """
 
-import logging
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from datasets import Dataset, DatasetDict
-
-logger = logging.getLogger(__name__)
+import numpy as np
+import pandas as pd
+from datasets import ClassLabel, Dataset, DatasetDict
 
 
 class SplitStrategy(str, Enum):
@@ -25,6 +22,19 @@ class SplitStrategy(str, Enum):
     SEQUENCE_UNIQUE = "sequence_unique"
     STRATIFIED = "stratified"
 
+    @classmethod
+    def _missing_(cls, value: object) -> "SplitStrategy":
+        # Accept hyphens as well as underscores (e.g. "sequence-unique")
+        if isinstance(value, str):
+            normalized = value.lower().replace("-", "_")
+            for member in cls:
+                if member.value == normalized:
+                    return member
+        valid = [m.value for m in cls]
+        raise ValueError(
+            f"{value!r} is not a valid split strategy. " f"Valid options are: {valid}"
+        )
+
 
 @dataclass(frozen=True)
 class SplitConfig:
@@ -33,32 +43,23 @@ class SplitConfig:
 
     Parameters
     ----------
-    val_ratio : float
-        Ratio of validation data (0 < val_ratio < 1). Default is 0.2.
+    val_ratio : Optional[float]
+        Fraction of data for the validation split. None or 0 means no val split. Default None.
     test_ratio : Optional[float]
-        Ratio of test data for three-way splits (0 < test_ratio < 1).
-        If None, only train/val split is performed. Default is None.
+        Fraction of data for the test split. None or 0 means no test split. Default None.
     strategy : str or SplitStrategy
-        Splitting strategy to use. Options: 'random', 'sequence_unique', 'stratified'.
-        Default is 'random'.
+        One of 'random', 'sequence_unique', 'stratified'. Default 'random'.
     seed : Optional[int]
-        Random seed for reproducibility. Default is None.
+        Random seed for reproducibility. Default None.
     stratify_column : Optional[str]
-        Column name to use for stratified splitting. Can be a label column or
-        any other feature column. Only used with 'stratified' strategy. Default is None.
+        Column to stratify on. Required for 'stratified' strategy. Default None.
     sequence_column : str
-        Column name containing sequences. Used for 'sequence_unique' strategy.
-        Default is 'sequence'.
-    Raises
-    ------
-    ValueError
-        If val_ratio or test_ratio are not in valid range (0, 1).
-        If val_ratio + test_ratio >= 1.
-        If stratify_column is not provided for stratified strategy.
-        If sequence_column is not provided for sequence_unique strategy.
+        Sequence column name. Used by 'sequence_unique' strategy. Default 'sequence'.
+
+    At least one of val_ratio or test_ratio must be provided and > 0.
     """
 
-    val_ratio: float = 0.2
+    val_ratio: Optional[float] = None
     test_ratio: Optional[float] = None
     strategy: str = "random"
     seed: Optional[int] = None
@@ -66,26 +67,34 @@ class SplitConfig:
     sequence_column: str = "sequence"
 
     def __post_init__(self):
-        """Validate configuration parameters."""
-        # Normalize strategy to enum
         if isinstance(self.strategy, str):
             object.__setattr__(self, "strategy", SplitStrategy(self.strategy.lower()))
 
-        # Validate ratios
-        if not 0 < self.val_ratio < 1:
+        # Treat 0 the same as None: no split for that portion
+        if self.val_ratio == 0:
+            object.__setattr__(self, "val_ratio", None)
+        if self.test_ratio == 0:
+            object.__setattr__(self, "test_ratio", None)
+
+        if self.val_ratio is None and self.test_ratio is None:
+            raise ValueError(
+                "At least one of val_ratio or test_ratio must be set and > 0."
+            )
+
+        if self.val_ratio is not None and not 0 < self.val_ratio < 1:
             raise ValueError(f"val_ratio must be between 0 and 1, got {self.val_ratio}")
 
-        if self.test_ratio is not None:
-            if not 0 < self.test_ratio < 1:
-                raise ValueError(
-                    f"test_ratio must be between 0 and 1, got {self.test_ratio}"
-                )
+        if self.test_ratio is not None and not 0 < self.test_ratio < 1:
+            raise ValueError(
+                f"test_ratio must be between 0 and 1, got {self.test_ratio}"
+            )
+
+        if self.val_ratio is not None and self.test_ratio is not None:
             if self.val_ratio + self.test_ratio >= 1:
                 raise ValueError(
                     f"val_ratio + test_ratio must be < 1, got {self.val_ratio + self.test_ratio}"
                 )
 
-        # Validate strategy-specific requirements
         if self.strategy == SplitStrategy.STRATIFIED and self.stratify_column is None:
             raise ValueError(
                 "stratify_column must be provided for stratified splitting strategy"
@@ -101,23 +110,24 @@ class SplitConfig:
 
 
 class DatasetSplitter(ABC):
-    """
-    Abstract base class for dataset splitting strategies.
-
-    This class follows the processor pattern used in the dlomix codebase,
-    providing a consistent interface for different splitting strategies.
-    """
+    """Abstract base class for dataset splitting strategies."""
 
     def __init__(self, config: SplitConfig):
-        """
-        Initialize the splitter with a configuration.
-
-        Parameters
-        ----------
-        config : SplitConfig
-            Configuration object containing splitting parameters.
-        """
         self.config = config
+
+    def _check_min_split_size(
+        self, n_samples: int, ratio: float, split_names: list
+    ) -> None:
+        """Raise ValueError if any split would be empty."""
+        n_second = max(1, round(n_samples * ratio))
+        n_first = n_samples - n_second
+        if n_first < 1 or n_second < 1:
+            raise ValueError(
+                f"Dataset too small for the requested split ratios: "
+                f"{n_samples} samples with ratio {ratio:.2f} would produce "
+                f"splits {split_names} with sizes {n_first} / {n_second}. "
+                f"Provide more data or reduce the split ratio."
+            )
 
     @abstractmethod
     def split(self, dataset: Dataset) -> DatasetDict:
@@ -132,37 +142,20 @@ class DatasetSplitter(ABC):
         Returns
         -------
         DatasetDict
-            Dictionary containing 'train', 'val', and optionally 'test' splits.
+            Dictionary with 'train' and any combination of 'val' / 'test' splits.
         """
 
     def _perform_two_way_split(
-        self, dataset: Dataset, test_size: float, seed: Optional[int] = None, **kwargs
+        self,
+        dataset: Dataset,
+        ratio: float,
+        second_name: str = "val",
+        seed: Optional[int] = None,
+        **kwargs,
     ) -> DatasetDict:
-        """
-        Helper method to perform a two-way split.
-
-        Parameters
-        ----------
-        dataset : Dataset
-            Dataset to split.
-        test_size : float
-            Ratio of the second split.
-        seed : Optional[int]
-            Random seed for reproducibility.
-        **kwargs
-            Additional arguments passed to train_test_split.
-
-        Returns
-        -------
-        DatasetDict
-            Dictionary with 'train' and 'val' keys.
-        """
-        split_dataset = dataset.train_test_split(
-            test_size=test_size, seed=seed, **kwargs
-        )
-        return DatasetDict(
-            {"train": split_dataset["train"], "val": split_dataset["test"]}
-        )
+        self._check_min_split_size(len(dataset), ratio, ["train", second_name])
+        split = dataset.train_test_split(test_size=ratio, seed=seed, **kwargs)
+        return DatasetDict({"train": split["train"], second_name: split["test"]})
 
     def _perform_three_way_split(
         self,
@@ -172,342 +165,192 @@ class DatasetSplitter(ABC):
         seed: Optional[int] = None,
         **kwargs,
     ) -> DatasetDict:
-        """
-        Helper method to perform a three-way split.
-
-        Parameters
-        ----------
-        dataset : Dataset
-            Dataset to split.
-        val_size : float
-            Ratio of validation data.
-        test_size : float
-            Ratio of test data.
-        seed : Optional[int]
-            Random seed for reproducibility.
-        **kwargs
-            Additional arguments passed to train_test_split.
-
-        Returns
-        -------
-        DatasetDict
-            Dictionary with 'train', 'val', and 'test' keys.
-        """
-        # First split: separate test set
-        first_split = dataset.train_test_split(test_size=test_size, seed=seed, **kwargs)
-        test_dataset = first_split["test"]
-        train_val_dataset = first_split["train"]
-
-        # Calculate adjusted val ratio for remaining data
-        adjusted_val_ratio = val_size / (1 - test_size)
-
-        # Second split: separate train and val from remaining data
-        second_split = train_val_dataset.train_test_split(
-            test_size=adjusted_val_ratio, seed=seed, **kwargs
+        self._check_min_split_size(len(dataset), test_size, ["train", "val", "test"])
+        first = dataset.train_test_split(test_size=test_size, seed=seed, **kwargs)
+        # val_size is expressed as a fraction of the full dataset; adjust for the remaining portion
+        adjusted_val = val_size / (1 - test_size)
+        second = first["train"].train_test_split(
+            test_size=adjusted_val, seed=seed, **kwargs
         )
-
         return DatasetDict(
-            {
-                "train": second_split["train"],
-                "val": second_split["test"],
-                "test": test_dataset,
-            }
+            {"train": second["train"], "val": second["test"], "test": first["test"]}
         )
 
 
 class RandomSplitter(DatasetSplitter):
-    """
-    Random splitting strategy.
-
-    Splits dataset randomly into train/val or train/val/test sets.
-    Uses HuggingFace's train_test_split with optional seed for reproducibility.
-    """
+    """Splits dataset randomly into train/val, train/test, or train/val/test sets."""
 
     def split(self, dataset: Dataset) -> DatasetDict:
-        """
-        Perform random splitting.
-
-        Parameters
-        ----------
-        dataset : Dataset
-            HuggingFace Dataset to split.
-
-        Returns
-        -------
-        DatasetDict
-            Dictionary containing split datasets.
-        """
-        logger.info(
-            "Performing random split with val_ratio=%.2f, test_ratio=%s, seed=%s",
-            self.config.val_ratio,
-            self.config.test_ratio,
-            self.config.seed,
-        )
-
-        if self.config.test_ratio is None:
-            # Two-way split: train/val
-            return self._perform_two_way_split(
-                dataset, test_size=self.config.val_ratio, seed=self.config.seed
-            )
-        else:
-            # Three-way split: train/val/test
+        val, test = self.config.val_ratio, self.config.test_ratio
+        if val and test:
             return self._perform_three_way_split(
-                dataset,
-                val_size=self.config.val_ratio,
-                test_size=self.config.test_ratio,
-                seed=self.config.seed,
+                dataset, val_size=val, test_size=test, seed=self.config.seed
             )
+        if val:
+            return self._perform_two_way_split(
+                dataset, ratio=val, second_name="val", seed=self.config.seed
+            )
+        return self._perform_two_way_split(
+            dataset, ratio=test, second_name="test", seed=self.config.seed  # type: ignore[arg-type]
+        )
 
 
 class StratifiedSplitter(DatasetSplitter):
-    """
-    Stratified splitting strategy.
-
-    Splits dataset while maintaining the distribution of a specified column
-    (e.g., label column or any feature column) across splits.
-    """
+    """Splits dataset while preserving the class distribution of a given column."""
 
     def split(self, dataset: Dataset) -> DatasetDict:
-        """
-        Perform stratified splitting.
-
-        Parameters
-        ----------
-        dataset : Dataset
-            HuggingFace Dataset to split.
-
-        Returns
-        -------
-        DatasetDict
-            Dictionary containing split datasets.
-
-        Raises
-        ------
-        ValueError
-            If stratify_column is not found in the dataset.
-        """
-        # Validate stratify column exists
         if self.config.stratify_column not in dataset.column_names:
             raise ValueError(
                 f"Stratification column '{self.config.stratify_column}' not found in dataset. "
                 f"Available columns: {dataset.column_names}"
             )
 
-        logger.info(
-            "Performing stratified split on column '%s' with val_ratio=%.2f, test_ratio=%s, seed=%s",
-            self.config.stratify_column,
-            self.config.val_ratio,
-            self.config.test_ratio,
-            self.config.seed,
-        )
-
-        if self.config.test_ratio is None:
-            # Two-way split: train/val
-            return self._perform_two_way_split(
-                dataset,
-                test_size=self.config.val_ratio,
-                seed=self.config.seed,
-                stratify_by_column=self.config.stratify_column,
+        # HF train_test_split requires ClassLabel feature type for stratification.
+        # Auto-cast if the column is a plain Value type so users don't need to do this manually.
+        if not isinstance(dataset.features[self.config.stratify_column], ClassLabel):
+            warnings.warn(
+                f"Stratification column '{self.config.stratify_column}' is not ClassLabel type "
+                f"(got {dataset.features[self.config.stratify_column]}). "
+                f"Auto-casting to ClassLabel for stratified splitting."
             )
-        else:
-            # Three-way split: train/val/test
+            dataset = dataset.class_encode_column(self.config.stratify_column)
+
+        val, test = self.config.val_ratio, self.config.test_ratio
+        strat = self.config.stratify_column
+        if val and test:
             return self._perform_three_way_split(
                 dataset,
-                val_size=self.config.val_ratio,
-                test_size=self.config.test_ratio,
+                val_size=val,
+                test_size=test,
                 seed=self.config.seed,
-                stratify_by_column=self.config.stratify_column,
+                stratify_by_column=strat,
             )
+        if val:
+            return self._perform_two_way_split(
+                dataset,
+                ratio=val,
+                second_name="val",
+                seed=self.config.seed,
+                stratify_by_column=strat,
+            )
+        return self._perform_two_way_split(
+            dataset,
+            ratio=test,
+            second_name="test",
+            seed=self.config.seed,  # type: ignore[arg-type]
+            stratify_by_column=strat,
+        )
 
 
 class SequenceUniqueSplitter(DatasetSplitter):
     """
-    Sequence-based unique splitting strategy.
+    Splits dataset so that each base sequence appears in exactly one split.
 
-    Ensures that sequences are unique across train/val splits and optionally
-    test split. This is important for preventing data leakage when the same
-    sequence appears in both training and validation sets.
+    PTM notation (e.g. [UNIMOD:1], [+57]) is stripped before grouping, so
+    PEPTIDE and PEP[UNIMOD:1]TIDE are treated as the same sequence.
     """
 
     def split(self, dataset: Dataset) -> DatasetDict:
-        """
-        Perform sequence-unique splitting.
-
-        Parameters
-        ----------
-        dataset : Dataset
-            HuggingFace Dataset to split.
-
-        Returns
-        -------
-        DatasetDict
-            Dictionary containing split datasets with unique sequences.
-
-        Raises
-        ------
-        ValueError
-            If sequence_column is not found in the dataset.
-        """
-        # Validate sequence column exists
         if self.config.sequence_column not in dataset.column_names:
             raise ValueError(
                 f"Sequence column '{self.config.sequence_column}' not found in dataset. "
                 f"Available columns: {dataset.column_names}"
             )
 
-        logger.info(
-            "Performing sequence-unique split with val_ratio=%.2f, test_ratio=%s, seed=%s",
-            self.config.val_ratio,
-            self.config.test_ratio,
-            self.config.seed,
+        df = dataset.to_pandas()
+        assert isinstance(df, pd.DataFrame)
+
+        # Strip PTM notation before computing unique sequences so that
+        # PEPTIDE and PEP[UNIMOD:1]TIDE map to the same base sequence.
+        base_sequences = df[self.config.sequence_column].str.replace(
+            r"\[.*?\]", "", regex=True
         )
-
-        # Convert to pandas for easier groupby operations
-        import pandas as pd
-
-        df: pd.DataFrame = dataset.to_pandas()
-
-        # Group by sequence to get unique sequences
-        unique_sequences = df[self.config.sequence_column].unique()
+        unique_sequences = base_sequences.unique()
         n_unique = len(unique_sequences)
 
-        logger.info(
-            "Dataset contains %d total samples with %d unique sequences",
-            len(df),
-            n_unique,
-        )
-
-        # Create a dataset of unique sequences for splitting
-        import numpy as np
-
         rng = np.random.default_rng(self.config.seed)
+        shuffled = unique_sequences.copy()
+        rng.shuffle(shuffled)
 
-        # Shuffle unique sequences
-        shuffled_sequences = unique_sequences.copy()
-        rng.shuffle(shuffled_sequences)
+        val, test = self.config.val_ratio, self.config.test_ratio
 
-        # Calculate split indices
-        if self.config.test_ratio is None:
-            # Two-way split
-            val_size = int(n_unique * self.config.val_ratio)
-            train_sequences = shuffled_sequences[val_size:]
-            val_sequences = shuffled_sequences[:val_size]
-            test_sequences = None
-
-            logger.info(
-                "Split into %d train sequences, %d val sequences",
-                len(train_sequences),
-                len(val_sequences),
-            )
+        if val and test:
+            test_size = max(1, int(n_unique * test))
+            val_size = max(1, int(n_unique * val))
+            if n_unique - test_size - val_size < 1:
+                raise ValueError(
+                    f"Dataset too small: {n_unique} unique base sequences with "
+                    f"val_ratio={val}, test_ratio={test} would leave no train sequences."
+                )
+            test_seqs = shuffled[:test_size]
+            val_seqs = shuffled[test_size : test_size + val_size]
+            train_seqs = shuffled[test_size + val_size :]
+        elif val:
+            val_size = max(1, int(n_unique * val))
+            if n_unique - val_size < 1:
+                raise ValueError(
+                    f"Dataset too small: {n_unique} unique base sequences with "
+                    f"val_ratio={val} would leave no train sequences."
+                )
+            val_seqs = shuffled[:val_size]
+            train_seqs = shuffled[val_size:]
+            test_seqs = None
         else:
-            # Three-way split
-            test_size = int(n_unique * self.config.test_ratio)
-            val_size = int(n_unique * self.config.val_ratio)
+            assert test is not None
+            test_size = max(1, int(n_unique * test))
+            if n_unique - test_size < 1:
+                raise ValueError(
+                    f"Dataset too small: {n_unique} unique base sequences with "
+                    f"test_ratio={test} would leave no train sequences."
+                )
+            test_seqs = shuffled[:test_size]
+            train_seqs = shuffled[test_size:]
+            val_seqs = None
 
-            test_sequences = shuffled_sequences[:test_size]
-            val_sequences = shuffled_sequences[test_size : test_size + val_size]
-            train_sequences = shuffled_sequences[test_size + val_size :]
-
-            logger.info(
-                "Split into %d train sequences, %d val sequences, %d test sequences",
-                len(train_sequences),
-                len(val_sequences),
-                len(test_sequences),
-            )
-
-        # Filter dataframe by sequence membership
-        train_mask = df[self.config.sequence_column].isin(train_sequences)
-        val_mask = df[self.config.sequence_column].isin(val_sequences)
-
-        train_df = df[train_mask]
-        val_df = df[val_mask]
-
-        logger.info(
-            "Train split: %d samples, Val split: %d samples",
-            len(train_df),
-            len(val_df),
-        )
-
-        # Convert back to HuggingFace datasets
+        train_mask = base_sequences.isin(train_seqs)
         result = DatasetDict(
-            {
-                "train": Dataset.from_pandas(train_df, preserve_index=False),
-                "val": Dataset.from_pandas(val_df, preserve_index=False),
-            }
+            {"train": Dataset.from_pandas(df[train_mask], preserve_index=False)}
         )
+        split_bases = {"train": set(base_sequences[train_mask])}
 
-        # Handle test split
-        if test_sequences is not None:
-            test_df = df[df[self.config.sequence_column].isin(test_sequences)]
-            logger.info("Test split: %d samples", len(test_df))
-            result["test"] = Dataset.from_pandas(test_df, preserve_index=False)
+        if val_seqs is not None:
+            val_mask = base_sequences.isin(val_seqs)
+            result["val"] = Dataset.from_pandas(df[val_mask], preserve_index=False)
+            split_bases["val"] = set(base_sequences[val_mask])
 
-        # Verify uniqueness
-        train_seqs = set(result["train"][self.config.sequence_column])
-        val_seqs = set(result["val"][self.config.sequence_column])
+        if test_seqs is not None:
+            test_mask = base_sequences.isin(test_seqs)
+            result["test"] = Dataset.from_pandas(df[test_mask], preserve_index=False)
+            split_bases["test"] = set(base_sequences[test_mask])
 
-        if "test" in result:
-            test_seqs = set(result["test"][self.config.sequence_column])
-            train_val_overlap = train_seqs & val_seqs
-            train_test_overlap = train_seqs & test_seqs
-            val_test_overlap = val_seqs & test_seqs
-
-            if train_val_overlap or train_test_overlap or val_test_overlap:
-                warnings.warn(
-                    f"Sequence overlap detected after splitting: "
-                    f"train-val: {len(train_val_overlap)}, "
-                    f"train-test: {len(train_test_overlap)}, "
-                    f"val-test: {len(val_test_overlap)}"
-                )
-        else:
-            overlap = train_seqs & val_seqs
-            if overlap:
-                warnings.warn(
-                    f"Sequence overlap detected between train and val: {len(overlap)} sequences"
-                )
+        # Verify no base-sequence leakage across splits
+        names = list(split_bases)
+        for i, a in enumerate(names):
+            for b in names[i + 1 :]:
+                overlap = split_bases[a] & split_bases[b]
+                if overlap:
+                    warnings.warn(
+                        f"Base-sequence overlap between {a} and {b}: {len(overlap)} sequences"
+                    )
 
         return result
 
 
 def create_splitter(config: SplitConfig) -> DatasetSplitter:
     """
-    Factory method to create the appropriate splitter based on configuration.
-
-    Parameters
-    ----------
-    config : SplitConfig
-        Configuration object specifying the splitting strategy and parameters.
-
-    Returns
-    -------
-    DatasetSplitter
-        Concrete splitter instance based on the specified strategy.
-
-    Raises
-    ------
-    ValueError
-        If an unknown strategy is specified.
+    Create the appropriate splitter for the given configuration.
 
     Examples
     --------
-    >>> # Random splitting
     >>> config = SplitConfig(val_ratio=0.2, strategy='random', seed=42)
     >>> splitter = create_splitter(config)
     >>> split_data = splitter.split(dataset)
 
-    >>> # Stratified splitting by label
     >>> config = SplitConfig(val_ratio=0.2, strategy='stratified', stratify_column='label', seed=42)
     >>> splitter = create_splitter(config)
     >>> split_data = splitter.split(dataset)
 
-    >>> # Sequence-unique splitting with three-way split
-    >>> config = SplitConfig(
-    ...     val_ratio=0.15,
-    ...     test_ratio=0.15,
-    ...     strategy='sequence_unique',
-    ...     sequence_column='sequence',
-    ...     seed=42
-    ... )
+    >>> config = SplitConfig(val_ratio=0.15, test_ratio=0.15, strategy='sequence_unique', seed=42)
     >>> splitter = create_splitter(config)
     >>> split_data = splitter.split(dataset)
     """
@@ -516,13 +359,4 @@ def create_splitter(config: SplitConfig) -> DatasetSplitter:
         SplitStrategy.STRATIFIED: StratifiedSplitter,
         SplitStrategy.SEQUENCE_UNIQUE: SequenceUniqueSplitter,
     }
-
-    splitter_class = strategy_map.get(config.strategy)
-
-    if splitter_class is None:
-        raise ValueError(
-            f"Unknown splitting strategy: {config.strategy}. "
-            f"Available strategies: {list(strategy_map.keys())}"
-        )
-
-    return splitter_class(config)
+    return strategy_map[config.strategy](config)  # type: ignore[index]

--- a/src/dlomix/data/dataset_splitter.py
+++ b/src/dlomix/data/dataset_splitter.py
@@ -1,0 +1,547 @@
+"""
+Dataset splitting strategies for peptide datasets.
+
+This module provides a flexible and extensible framework for splitting datasets
+using various strategies including random, sequence-based uniqueness, and stratified
+splitting.
+"""
+
+import logging
+import warnings
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from datasets import Dataset, DatasetDict
+
+logger = logging.getLogger(__name__)
+
+
+class SplitStrategy(str, Enum):
+    """Enumeration of available dataset splitting strategies."""
+
+    RANDOM = "random"
+    SEQUENCE_UNIQUE = "sequence_unique"
+    STRATIFIED = "stratified"
+
+
+@dataclass(frozen=True)
+class SplitConfig:
+    """
+    Configuration for dataset splitting.
+
+    Parameters
+    ----------
+    val_ratio : float
+        Ratio of validation data (0 < val_ratio < 1). Default is 0.2.
+    test_ratio : Optional[float]
+        Ratio of test data for three-way splits (0 < test_ratio < 1).
+        If None, only train/val split is performed. Default is None.
+    strategy : str or SplitStrategy
+        Splitting strategy to use. Options: 'random', 'sequence_unique', 'stratified'.
+        Default is 'random'.
+    seed : Optional[int]
+        Random seed for reproducibility. Default is None.
+    stratify_column : Optional[str]
+        Column name to use for stratified splitting. Can be a label column or
+        any other feature column. Only used with 'stratified' strategy. Default is None.
+    sequence_column : str
+        Column name containing sequences. Used for 'sequence_unique' strategy.
+        Default is 'sequence'.
+    test_uniqueness : bool
+        If True, ensures test sequences are also unique from train/val when using
+        'sequence_unique' strategy. Default is True.
+
+    Raises
+    ------
+    ValueError
+        If val_ratio or test_ratio are not in valid range (0, 1).
+        If val_ratio + test_ratio >= 1.
+        If stratify_column is not provided for stratified strategy.
+        If sequence_column is not provided for sequence_unique strategy.
+    """
+
+    val_ratio: float = 0.2
+    test_ratio: Optional[float] = None
+    strategy: str = "random"
+    seed: Optional[int] = None
+    stratify_column: Optional[str] = None
+    sequence_column: str = "sequence"
+    test_uniqueness: bool = True
+
+    def __post_init__(self):
+        """Validate configuration parameters."""
+        # Normalize strategy to enum
+        if isinstance(self.strategy, str):
+            object.__setattr__(self, "strategy", SplitStrategy(self.strategy.lower()))
+
+        # Validate ratios
+        if not 0 < self.val_ratio < 1:
+            raise ValueError(f"val_ratio must be between 0 and 1, got {self.val_ratio}")
+
+        if self.test_ratio is not None:
+            if not 0 < self.test_ratio < 1:
+                raise ValueError(
+                    f"test_ratio must be between 0 and 1, got {self.test_ratio}"
+                )
+            if self.val_ratio + self.test_ratio >= 1:
+                raise ValueError(
+                    f"val_ratio + test_ratio must be < 1, got {self.val_ratio + self.test_ratio}"
+                )
+
+        # Validate strategy-specific requirements
+        if self.strategy == SplitStrategy.STRATIFIED and self.stratify_column is None:
+            raise ValueError(
+                "stratify_column must be provided for stratified splitting strategy"
+            )
+
+        if (
+            self.strategy == SplitStrategy.SEQUENCE_UNIQUE
+            and self.sequence_column is None
+        ):
+            raise ValueError(
+                "sequence_column must be provided for sequence_unique splitting strategy"
+            )
+
+
+class DatasetSplitter(ABC):
+    """
+    Abstract base class for dataset splitting strategies.
+
+    This class follows the processor pattern used in the dlomix codebase,
+    providing a consistent interface for different splitting strategies.
+    """
+
+    def __init__(self, config: SplitConfig):
+        """
+        Initialize the splitter with a configuration.
+
+        Parameters
+        ----------
+        config : SplitConfig
+            Configuration object containing splitting parameters.
+        """
+        self.config = config
+
+    @abstractmethod
+    def split(self, dataset: Dataset) -> DatasetDict:
+        """
+        Split a dataset according to the configured strategy.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            HuggingFace Dataset to split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary containing 'train', 'val', and optionally 'test' splits.
+        """
+
+    def _perform_two_way_split(
+        self, dataset: Dataset, test_size: float, seed: Optional[int] = None, **kwargs
+    ) -> DatasetDict:
+        """
+        Helper method to perform a two-way split.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            Dataset to split.
+        test_size : float
+            Ratio of the second split.
+        seed : Optional[int]
+            Random seed for reproducibility.
+        **kwargs
+            Additional arguments passed to train_test_split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary with 'train' and 'val' keys.
+        """
+        split_dataset = dataset.train_test_split(
+            test_size=test_size, seed=seed, **kwargs
+        )
+        return DatasetDict(
+            {"train": split_dataset["train"], "val": split_dataset["test"]}
+        )
+
+    def _perform_three_way_split(
+        self,
+        dataset: Dataset,
+        val_size: float,
+        test_size: float,
+        seed: Optional[int] = None,
+        **kwargs,
+    ) -> DatasetDict:
+        """
+        Helper method to perform a three-way split.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            Dataset to split.
+        val_size : float
+            Ratio of validation data.
+        test_size : float
+            Ratio of test data.
+        seed : Optional[int]
+            Random seed for reproducibility.
+        **kwargs
+            Additional arguments passed to train_test_split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary with 'train', 'val', and 'test' keys.
+        """
+        # First split: separate test set
+        first_split = dataset.train_test_split(test_size=test_size, seed=seed, **kwargs)
+        test_dataset = first_split["test"]
+        train_val_dataset = first_split["train"]
+
+        # Calculate adjusted val ratio for remaining data
+        adjusted_val_ratio = val_size / (1 - test_size)
+
+        # Second split: separate train and val from remaining data
+        second_split = train_val_dataset.train_test_split(
+            test_size=adjusted_val_ratio, seed=seed, **kwargs
+        )
+
+        return DatasetDict(
+            {
+                "train": second_split["train"],
+                "val": second_split["test"],
+                "test": test_dataset,
+            }
+        )
+
+
+class RandomSplitter(DatasetSplitter):
+    """
+    Random splitting strategy.
+
+    Splits dataset randomly into train/val or train/val/test sets.
+    Uses HuggingFace's train_test_split with optional seed for reproducibility.
+    """
+
+    def split(self, dataset: Dataset) -> DatasetDict:
+        """
+        Perform random splitting.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            HuggingFace Dataset to split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary containing split datasets.
+        """
+        logger.info(
+            "Performing random split with val_ratio=%.2f, test_ratio=%s, seed=%s",
+            self.config.val_ratio,
+            self.config.test_ratio,
+            self.config.seed,
+        )
+
+        if self.config.test_ratio is None:
+            # Two-way split: train/val
+            return self._perform_two_way_split(
+                dataset, test_size=self.config.val_ratio, seed=self.config.seed
+            )
+        else:
+            # Three-way split: train/val/test
+            return self._perform_three_way_split(
+                dataset,
+                val_size=self.config.val_ratio,
+                test_size=self.config.test_ratio,
+                seed=self.config.seed,
+            )
+
+
+class StratifiedSplitter(DatasetSplitter):
+    """
+    Stratified splitting strategy.
+
+    Splits dataset while maintaining the distribution of a specified column
+    (e.g., label column or any feature column) across splits.
+    """
+
+    def split(self, dataset: Dataset) -> DatasetDict:
+        """
+        Perform stratified splitting.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            HuggingFace Dataset to split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary containing split datasets.
+
+        Raises
+        ------
+        ValueError
+            If stratify_column is not found in the dataset.
+        """
+        # Validate stratify column exists
+        if self.config.stratify_column not in dataset.column_names:
+            raise ValueError(
+                f"Stratification column '{self.config.stratify_column}' not found in dataset. "
+                f"Available columns: {dataset.column_names}"
+            )
+
+        logger.info(
+            "Performing stratified split on column '%s' with val_ratio=%.2f, test_ratio=%s, seed=%s",
+            self.config.stratify_column,
+            self.config.val_ratio,
+            self.config.test_ratio,
+            self.config.seed,
+        )
+
+        if self.config.test_ratio is None:
+            # Two-way split: train/val
+            return self._perform_two_way_split(
+                dataset,
+                test_size=self.config.val_ratio,
+                seed=self.config.seed,
+                stratify_by_column=self.config.stratify_column,
+            )
+        else:
+            # Three-way split: train/val/test
+            return self._perform_three_way_split(
+                dataset,
+                val_size=self.config.val_ratio,
+                test_size=self.config.test_ratio,
+                seed=self.config.seed,
+                stratify_by_column=self.config.stratify_column,
+            )
+
+
+class SequenceUniqueSplitter(DatasetSplitter):
+    """
+    Sequence-based unique splitting strategy.
+
+    Ensures that sequences are unique across train/val splits and optionally
+    test split. This is important for preventing data leakage when the same
+    sequence appears in both training and validation sets.
+    """
+
+    def split(self, dataset: Dataset) -> DatasetDict:
+        """
+        Perform sequence-unique splitting.
+
+        Parameters
+        ----------
+        dataset : Dataset
+            HuggingFace Dataset to split.
+
+        Returns
+        -------
+        DatasetDict
+            Dictionary containing split datasets with unique sequences.
+
+        Raises
+        ------
+        ValueError
+            If sequence_column is not found in the dataset.
+        """
+        # Validate sequence column exists
+        if self.config.sequence_column not in dataset.column_names:
+            raise ValueError(
+                f"Sequence column '{self.config.sequence_column}' not found in dataset. "
+                f"Available columns: {dataset.column_names}"
+            )
+
+        logger.info(
+            "Performing sequence-unique split with val_ratio=%.2f, test_ratio=%s, test_uniqueness=%s, seed=%s",
+            self.config.val_ratio,
+            self.config.test_ratio,
+            self.config.test_uniqueness,
+            self.config.seed,
+        )
+
+        # Convert to pandas for easier groupby operations
+        import pandas as pd
+
+        df: pd.DataFrame = dataset.to_pandas()
+
+        # Group by sequence to get unique sequences
+        unique_sequences = df[self.config.sequence_column].unique()
+        n_unique = len(unique_sequences)
+
+        logger.info(
+            "Dataset contains %d total samples with %d unique sequences",
+            len(df),
+            n_unique,
+        )
+
+        # Create a dataset of unique sequences for splitting
+        import numpy as np
+
+        rng = np.random.default_rng(self.config.seed)
+
+        # Shuffle unique sequences
+        shuffled_sequences = unique_sequences.copy()
+        rng.shuffle(shuffled_sequences)
+
+        # Calculate split indices
+        if self.config.test_ratio is None:
+            # Two-way split
+            val_size = int(n_unique * self.config.val_ratio)
+            train_sequences = shuffled_sequences[val_size:]
+            val_sequences = shuffled_sequences[:val_size]
+            test_sequences = None
+
+            logger.info(
+                "Split into %d train sequences, %d val sequences",
+                len(train_sequences),
+                len(val_sequences),
+            )
+        else:
+            # Three-way split
+            test_size = int(n_unique * self.config.test_ratio)
+            val_size = int(n_unique * self.config.val_ratio)
+
+            test_sequences = shuffled_sequences[:test_size]
+            val_sequences = shuffled_sequences[test_size : test_size + val_size]
+            train_sequences = shuffled_sequences[test_size + val_size :]
+
+            logger.info(
+                "Split into %d train sequences, %d val sequences, %d test sequences",
+                len(train_sequences),
+                len(val_sequences),
+                len(test_sequences),
+            )
+
+        # Filter dataframe by sequence membership
+        train_mask = df[self.config.sequence_column].isin(train_sequences)
+        val_mask = df[self.config.sequence_column].isin(val_sequences)
+
+        train_df = df[train_mask]
+        val_df = df[val_mask]
+
+        logger.info(
+            "Train split: %d samples, Val split: %d samples",
+            len(train_df),
+            len(val_df),
+        )
+
+        # Convert back to HuggingFace datasets
+        result = DatasetDict(
+            {
+                "train": Dataset.from_pandas(train_df, preserve_index=False),
+                "val": Dataset.from_pandas(val_df, preserve_index=False),
+            }
+        )
+
+        # Handle test split
+        if test_sequences is not None:
+            if self.config.test_uniqueness:
+                # Ensure test sequences are unique from train/val
+                test_mask = df[self.config.sequence_column].isin(test_sequences)
+            else:
+                # Allow test sequences to overlap with train/val
+                # Include all sequences not in train or val
+                test_mask = ~(train_mask | val_mask)
+
+            test_df = df[test_mask]
+            logger.info("Test split: %d samples", len(test_df))
+            result["test"] = Dataset.from_pandas(test_df, preserve_index=False)
+
+        # Verify uniqueness
+        if self.config.test_ratio is not None and self.config.test_uniqueness:
+            train_seqs = set(result["train"][self.config.sequence_column])
+            val_seqs = set(result["val"][self.config.sequence_column])
+            test_seqs = set(result["test"][self.config.sequence_column])
+
+            train_val_overlap = train_seqs & val_seqs
+            train_test_overlap = train_seqs & test_seqs
+            val_test_overlap = val_seqs & test_seqs
+
+            if train_val_overlap or train_test_overlap or val_test_overlap:
+                warnings.warn(
+                    f"Sequence overlap detected after splitting: "
+                    f"train-val: {len(train_val_overlap)}, "
+                    f"train-test: {len(train_test_overlap)}, "
+                    f"val-test: {len(val_test_overlap)}"
+                )
+        else:
+            # Verify train/val uniqueness for two-way split
+            train_seqs = set(result["train"][self.config.sequence_column])
+            val_seqs = set(result["val"][self.config.sequence_column])
+            overlap = train_seqs & val_seqs
+
+            if overlap:
+                warnings.warn(
+                    f"Sequence overlap detected between train and val: {len(overlap)} sequences"
+                )
+
+        return result
+
+
+def create_splitter(config: SplitConfig) -> DatasetSplitter:
+    """
+    Factory method to create the appropriate splitter based on configuration.
+
+    Parameters
+    ----------
+    config : SplitConfig
+        Configuration object specifying the splitting strategy and parameters.
+
+    Returns
+    -------
+    DatasetSplitter
+        Concrete splitter instance based on the specified strategy.
+
+    Raises
+    ------
+    ValueError
+        If an unknown strategy is specified.
+
+    Examples
+    --------
+    >>> # Random splitting
+    >>> config = SplitConfig(val_ratio=0.2, strategy='random', seed=42)
+    >>> splitter = create_splitter(config)
+    >>> split_data = splitter.split(dataset)
+
+    >>> # Stratified splitting by label
+    >>> config = SplitConfig(val_ratio=0.2, strategy='stratified', stratify_column='label', seed=42)
+    >>> splitter = create_splitter(config)
+    >>> split_data = splitter.split(dataset)
+
+    >>> # Sequence-unique splitting with three-way split
+    >>> config = SplitConfig(
+    ...     val_ratio=0.15,
+    ...     test_ratio=0.15,
+    ...     strategy='sequence_unique',
+    ...     sequence_column='sequence',
+    ...     test_uniqueness=True,
+    ...     seed=42
+    ... )
+    >>> splitter = create_splitter(config)
+    >>> split_data = splitter.split(dataset)
+    """
+    strategy_map = {
+        SplitStrategy.RANDOM: RandomSplitter,
+        SplitStrategy.STRATIFIED: StratifiedSplitter,
+        SplitStrategy.SEQUENCE_UNIQUE: SequenceUniqueSplitter,
+    }
+
+    splitter_class = strategy_map.get(config.strategy)
+
+    if splitter_class is None:
+        raise ValueError(
+            f"Unknown splitting strategy: {config.strategy}. "
+            f"Available strategies: {list(strategy_map.keys())}"
+        )
+
+    return splitter_class(config)

--- a/src/dlomix/data/dataset_splitter.py
+++ b/src/dlomix/data/dataset_splitter.py
@@ -49,10 +49,6 @@ class SplitConfig:
     sequence_column : str
         Column name containing sequences. Used for 'sequence_unique' strategy.
         Default is 'sequence'.
-    test_uniqueness : bool
-        If True, ensures test sequences are also unique from train/val when using
-        'sequence_unique' strategy. Default is True.
-
     Raises
     ------
     ValueError
@@ -68,7 +64,6 @@ class SplitConfig:
     seed: Optional[int] = None
     stratify_column: Optional[str] = None
     sequence_column: str = "sequence"
-    test_uniqueness: bool = True
 
     def __post_init__(self):
         """Validate configuration parameters."""
@@ -361,10 +356,9 @@ class SequenceUniqueSplitter(DatasetSplitter):
             )
 
         logger.info(
-            "Performing sequence-unique split with val_ratio=%.2f, test_ratio=%s, test_uniqueness=%s, seed=%s",
+            "Performing sequence-unique split with val_ratio=%.2f, test_ratio=%s, seed=%s",
             self.config.val_ratio,
             self.config.test_ratio,
-            self.config.test_uniqueness,
             self.config.seed,
         )
 
@@ -444,24 +438,16 @@ class SequenceUniqueSplitter(DatasetSplitter):
 
         # Handle test split
         if test_sequences is not None:
-            if self.config.test_uniqueness:
-                # Ensure test sequences are unique from train/val
-                test_mask = df[self.config.sequence_column].isin(test_sequences)
-            else:
-                # Allow test sequences to overlap with train/val
-                # Include all sequences not in train or val
-                test_mask = ~(train_mask | val_mask)
-
-            test_df = df[test_mask]
+            test_df = df[df[self.config.sequence_column].isin(test_sequences)]
             logger.info("Test split: %d samples", len(test_df))
             result["test"] = Dataset.from_pandas(test_df, preserve_index=False)
 
         # Verify uniqueness
-        if self.config.test_ratio is not None and self.config.test_uniqueness:
-            train_seqs = set(result["train"][self.config.sequence_column])
-            val_seqs = set(result["val"][self.config.sequence_column])
-            test_seqs = set(result["test"][self.config.sequence_column])
+        train_seqs = set(result["train"][self.config.sequence_column])
+        val_seqs = set(result["val"][self.config.sequence_column])
 
+        if "test" in result:
+            test_seqs = set(result["test"][self.config.sequence_column])
             train_val_overlap = train_seqs & val_seqs
             train_test_overlap = train_seqs & test_seqs
             val_test_overlap = val_seqs & test_seqs
@@ -474,11 +460,7 @@ class SequenceUniqueSplitter(DatasetSplitter):
                     f"val-test: {len(val_test_overlap)}"
                 )
         else:
-            # Verify train/val uniqueness for two-way split
-            train_seqs = set(result["train"][self.config.sequence_column])
-            val_seqs = set(result["val"][self.config.sequence_column])
             overlap = train_seqs & val_seqs
-
             if overlap:
                 warnings.warn(
                     f"Sequence overlap detected between train and val: {len(overlap)} sequences"
@@ -524,7 +506,6 @@ def create_splitter(config: SplitConfig) -> DatasetSplitter:
     ...     test_ratio=0.15,
     ...     strategy='sequence_unique',
     ...     sequence_column='sequence',
-    ...     test_uniqueness=True,
     ...     seed=42
     ... )
     >>> splitter = create_splitter(config)

--- a/src/dlomix/data/detectability.py
+++ b/src/dlomix/data/detectability.py
@@ -16,7 +16,7 @@ class DetectabilityDataset(PeptideDataset):
         data_format (str): The format of the data source file(s). Default is "csv".
         sequence_column (str): The name of the column containing the peptide sequences. Default is "Sequences".
         label_column (str): The name of the column containing the class labels. Default is "Classes".
-        val_ratio (float): The ratio of validation data to split from the training data. Default is 0.2.
+        val_ratio (Optional[float]): Fraction of data for the validation split. None or 0 means no val split. Default None.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences. Default is 40.
         dataset_type (str): The type of dataset to use. Default is "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation. Default is 256.
@@ -50,7 +50,7 @@ class DetectabilityDataset(PeptideDataset):
         data_format: str = "csv",
         sequence_column: str = "Sequences",
         label_column: str = "Classes",
-        val_ratio: float = 0.2,
+        val_ratio: Optional[float] = None,
         max_seq_len: Union[int, str] = 40,
         dataset_type: str = "tf",
         batch_size: int = 256,

--- a/src/dlomix/data/detectability.py
+++ b/src/dlomix/data/detectability.py
@@ -36,6 +36,11 @@ class DetectabilityDataset(PeptideDataset):
         num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
+        split_strategy (Optional[str]): Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'. Default is 'random'.
+        split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
+        test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
+        stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
+        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -66,6 +71,11 @@ class DetectabilityDataset(PeptideDataset):
         num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
+        split_strategy: Optional[str] = "random",
+        split_seed: Optional[int] = None,
+        test_ratio: Optional[float] = None,
+        stratify_by_column: Optional[str] = None,
+        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/detectability.py
+++ b/src/dlomix/data/detectability.py
@@ -40,7 +40,6 @@ class DetectabilityDataset(PeptideDataset):
         split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
         test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
         stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
-        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -75,7 +74,6 @@ class DetectabilityDataset(PeptideDataset):
         split_seed: Optional[int] = None,
         test_ratio: Optional[float] = None,
         stratify_by_column: Optional[str] = None,
-        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -20,7 +20,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         data_format (str): The format of the data source file(s). Default is "parquet".
         sequence_column (str): The name of the column containing the peptide sequences. Default is "modified_sequence".
         label_column (str): The name of the column containing the intensity labels. Default is "intensities_raw".
-        val_ratio (float): The ratio of validation data to split from the training data. Default is 0.2.
+        val_ratio (Optional[float]): Fraction of data for the validation split. None or 0 means no val split. Default None.
         max_seq_len (Union[int, str]): The maximum length of the peptide sequences. Default is 30.
         dataset_type (str): The type of dataset to use (e.g., "tf" for TensorFlow dataset). Default is "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for training and evaluation. Default is 64.
@@ -55,7 +55,7 @@ class FragmentIonIntensityDataset(PeptideDataset):
         data_format: str = "parquet",
         sequence_column: str = "modified_sequence",
         label_column: str = "intensities_raw",
-        val_ratio: float = 0.2,
+        val_ratio: Optional[float] = None,
         max_seq_len: Union[int, str] = 30,
         dataset_type: str = "tf",
         batch_size: int = 64,

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -40,6 +40,11 @@ class FragmentIonIntensityDataset(PeptideDataset):
         num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
+        split_strategy (Optional[str]): Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'. Default is 'random'.
+        split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
+        test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
+        stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
+        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
         **kwargs: Additional arguments to pass to the parent class.
     """
 
@@ -71,6 +76,11 @@ class FragmentIonIntensityDataset(PeptideDataset):
         num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
+        split_strategy: Optional[str] = "random",
+        split_seed: Optional[int] = None,
+        test_ratio: Optional[float] = None,
+        stratify_by_column: Optional[str] = None,
+        test_uniqueness: bool = True,
         **kwargs,
     ):
         # Create config kwargs dictionary from all local parameters

--- a/src/dlomix/data/fragment_ion_intensity.py
+++ b/src/dlomix/data/fragment_ion_intensity.py
@@ -44,7 +44,6 @@ class FragmentIonIntensityDataset(PeptideDataset):
         split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
         test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
         stratify_by_column (Optional[str]): Column name for stratified splitting. Default is None.
-        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
         **kwargs: Additional arguments to pass to the parent class.
     """
 
@@ -80,7 +79,6 @@ class FragmentIonIntensityDataset(PeptideDataset):
         split_seed: Optional[int] = None,
         test_ratio: Optional[float] = None,
         stratify_by_column: Optional[str] = None,
-        test_uniqueness: bool = True,
         **kwargs,
     ):
         # Create config kwargs dictionary from all local parameters

--- a/src/dlomix/data/inference.py
+++ b/src/dlomix/data/inference.py
@@ -1,0 +1,350 @@
+"""
+Reusable, serializable preprocessing for inference on new peptide data.
+
+``PeptidePreprocessor`` captures the exact preprocessing recipe used to build a
+training dataset (learned alphabet, encoding scheme, padding, feature extractors) and
+applies it to raw inputs (strings, lists, numpy arrays, dicts, HF datasets, DataFrames),
+producing the same model-ready tensors a :class:`~dlomix.data.dataset.PeptideDataset`
+would. It can be created from a live dataset, from a saved dataset directory, or loaded
+from its own lightweight artifact for shipping alongside a model.
+"""
+
+import hashlib
+import json
+import warnings
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+from datasets import Dataset
+
+from .dataset_utils import EncodingScheme
+from .processing.chain import build_processing_chain
+from .processing.processors import SequencePaddingProcessor
+from .tensor_conversion import (
+    cast_feature_columns_to_float,
+    to_tf_tensor_dataset,
+    to_torch_dataloader,
+)
+
+ARTIFACT_NAME = "dlomix_preprocessor.json"
+
+
+class PeptidePreprocessor:
+    """Turn raw peptide inputs into model-ready tensors using a fixed recipe.
+
+    Parameters
+    ----------
+    alphabet : dict
+        Learned alphabet (token -> integer index), including padding and unknown tokens.
+    sequence_column : str
+        Name of the column holding peptide sequences.
+    max_seq_len : int
+        Maximum (unmodified) sequence length used during training.
+    padding_value : str
+        Padding token; must exist in ``alphabet``. Default '-'.
+    encoding_scheme : str or EncodingScheme
+        'unmod' or 'naive-mods'. Default 'unmod'.
+    with_termini : bool
+        Whether N/C termini were added to sequences. Default True.
+    model_features : list of str, optional
+        Feature columns carried into the model as tensors (must be present in inputs).
+    features_to_extract : list, optional
+        Built-in feature names (str) or custom callables, reproducing training features.
+    dataset_type : str
+        'tf' or 'pt'; selects the output tensor format. Default 'tf'.
+    batch_size : int
+        Batch size for the produced tensor dataset. Default 64.
+    batch_processing_size : int
+        Batch size for the internal ``.map()`` processing calls. Default 1000.
+    """
+
+    def __init__(
+        self,
+        alphabet: Dict[str, int],
+        sequence_column: str,
+        max_seq_len: int,
+        padding_value: str = "-",
+        encoding_scheme: Union[str, EncodingScheme] = EncodingScheme.UNMOD,
+        with_termini: bool = True,
+        model_features: Optional[List[str]] = None,
+        features_to_extract: Optional[List[Union[str, Callable]]] = None,
+        dataset_type: str = "tf",
+        batch_size: int = 64,
+        batch_processing_size: int = 1000,
+    ):
+        self.alphabet = dict(alphabet)
+        self.sequence_column = sequence_column
+        self.max_seq_len = max_seq_len
+        self.padding_value = padding_value
+        self.encoding_scheme = EncodingScheme(encoding_scheme)
+        self.with_termini = with_termini
+        self.model_features = list(model_features) if model_features else []
+        self.features_to_extract = (
+            list(features_to_extract) if features_to_extract else []
+        )
+        self.dataset_type = dataset_type
+        self.batch_size = batch_size
+        self.batch_processing_size = batch_processing_size
+
+        if self.padding_value not in self.alphabet:
+            raise ValueError(
+                f"padding_value '{self.padding_value}' is not present in the alphabet."
+            )
+
+        self.vocab_size = len(self.alphabet)
+        self._build_pipeline()
+
+    # ------------------------------------------------------------------ builders
+
+    def _build_pipeline(self) -> None:
+        """Build the inference processor chain (frozen vocabulary, fallback encoding).
+
+        This is the same chain the training pipeline applies to its test split, built
+        via the shared :func:`~dlomix.data.processing.chain.build_processing_chain`.
+        """
+        self._processors, self._extracted_feature_names = build_processing_chain(
+            sequence_column=self.sequence_column,
+            encoding_scheme=self.encoding_scheme,
+            with_termini=self.with_termini,
+            max_seq_len=self.max_seq_len,
+            padding_value=self.padding_value,
+            alphabet=self.alphabet,
+            pad=True,
+            features_to_extract=self.features_to_extract,
+            encoding_extend_alphabet=False,
+            encoding_fallback_unmodified=True,
+            warn_unmod=False,
+        )
+
+    @property
+    def input_columns(self) -> List[str]:
+        """Columns fed to the model as tensors (sequence + features), order stable."""
+        return [
+            self.sequence_column,
+            *self.model_features,
+            *self._extracted_feature_names,
+        ]
+
+    @property
+    def extracted_feature_names(self) -> List[str]:
+        """Names of features computed from the sequence (e.g. PTM features)."""
+        return list(self._extracted_feature_names)
+
+    @property
+    def fingerprint(self) -> str:
+        """Short stable hash of the recipe, used for model/preprocessor consistency."""
+        payload = json.dumps(
+            {
+                "alphabet": dict(sorted(self.alphabet.items())),
+                "sequence_column": self.sequence_column,
+                "max_seq_len": self.max_seq_len,
+                "padding_value": self.padding_value,
+                "encoding_scheme": self.encoding_scheme.value,
+                "with_termini": self.with_termini,
+                "model_features": sorted(self.model_features),
+                "features": sorted(self._extracted_feature_names),
+            },
+            sort_keys=True,
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+    # --------------------------------------------------------------- constructors
+
+    @classmethod
+    def from_dataset(cls, dataset) -> "PeptidePreprocessor":
+        """Build a preprocessor from a live, processed ``PeptideDataset``."""
+        if not getattr(dataset, "processed", False):
+            raise ValueError(
+                "Dataset must be processed before a preprocessor can be derived from it."
+            )
+        return cls(
+            alphabet=dataset.extended_alphabet,
+            sequence_column=dataset.sequence_column,
+            max_seq_len=dataset.max_seq_len,
+            padding_value=dataset.padding_value,
+            encoding_scheme=dataset.encoding_scheme,
+            with_termini=dataset.with_termini,
+            model_features=dataset.model_features,
+            features_to_extract=dataset.features_to_extract,
+            dataset_type=dataset.dataset_type,
+            batch_size=dataset.batch_size,
+            batch_processing_size=getattr(dataset, "batch_processing_size", 1000),
+        )
+
+    @classmethod
+    def from_saved(cls, path: str) -> "PeptidePreprocessor":
+        """Build a preprocessor from a ``PeptideDataset.save_to_disk`` directory.
+
+        Reads the config + metadata only; the HF data on disk is not loaded.
+        """
+        from .dataset import PeptideDataset  # local import to avoid a cycle
+
+        path_obj = Path(path)
+        config = json.loads(
+            (path_obj / PeptideDataset.CONFIG_JSON_NAME).read_text(encoding="utf-8")
+        )
+        metadata = json.loads(
+            (path_obj / PeptideDataset.METADATA_JSON_NAME).read_text(encoding="utf-8")
+        )
+        state = metadata.get("state", {})
+
+        alphabet = state.get("extended_alphabet")
+        if not alphabet:
+            raise ValueError(
+                f"No learned alphabet found in saved dataset metadata at {path}."
+            )
+
+        # Prefer the saved extracted column names (they're the ground truth for what was
+        # actually applied at training time). Fall back to config only if the key is absent
+        # (e.g. datasets saved before this attribute existed). An explicit empty list means
+        # no features were extracted — don't fall through to the config in that case.
+        extracted = state.get("_extracted_features_columns")
+        features_to_extract = (
+            extracted
+            if extracted is not None
+            else _string_features(config.get("features_to_extract"))
+        )
+
+        return cls(
+            alphabet=alphabet,
+            sequence_column=config["sequence_column"],
+            max_seq_len=config["max_seq_len"],
+            padding_value=config["padding_value"],
+            encoding_scheme=config["encoding_scheme"],
+            with_termini=config["with_termini"],
+            model_features=config.get("model_features"),
+            features_to_extract=features_to_extract,
+            dataset_type=config["dataset_type"],
+            batch_size=config.get("batch_size", 64),
+            batch_processing_size=config.get("batch_processing_size", 1000),
+        )
+
+    # --------------------------------------------------------------- persistence
+
+    def save(self, path: str) -> str:
+        """Save the recipe to a lightweight JSON artifact and return the file path."""
+        callable_features = [
+            f for f in self.features_to_extract if not isinstance(f, str)
+        ]
+        if callable_features:
+            warnings.warn(
+                "Custom callable feature extractors cannot be serialized and will be "
+                f"dropped on save: {[f.__name__ for f in callable_features]}. "
+                "Re-create the preprocessor with from_dataset() to retain them."
+            )
+
+        path_obj = Path(path)
+        if path_obj.suffix != ".json":
+            path_obj.mkdir(parents=True, exist_ok=True)
+            path_obj = path_obj / ARTIFACT_NAME
+
+        artifact = {
+            "alphabet": self.alphabet,
+            "sequence_column": self.sequence_column,
+            "max_seq_len": self.max_seq_len,
+            "padding_value": self.padding_value,
+            "encoding_scheme": self.encoding_scheme.value,
+            "with_termini": self.with_termini,
+            "model_features": self.model_features,
+            "features_to_extract": [
+                f for f in self.features_to_extract if isinstance(f, str)
+            ],
+            "dataset_type": self.dataset_type,
+            "batch_size": self.batch_size,
+            "batch_processing_size": self.batch_processing_size,
+            "fingerprint": self.fingerprint,
+        }
+        path_obj.write_text(json.dumps(artifact, indent=2), encoding="utf-8")
+        return str(path_obj)
+
+    @classmethod
+    def load(cls, path: str) -> "PeptidePreprocessor":
+        """Load a preprocessor from a JSON artifact (file or containing directory)."""
+        path_obj = Path(path)
+        if path_obj.is_dir():
+            path_obj = path_obj / ARTIFACT_NAME
+        artifact = json.loads(path_obj.read_text(encoding="utf-8"))
+        artifact.pop("fingerprint", None)
+        return cls(**artifact)
+
+    # ------------------------------------------------------------------ transform
+
+    def transform(self, inputs):
+        """Convert raw inputs into a backend tensor dataset ready for the model."""
+        hf_dataset = self._to_hf_dataset(inputs)
+        self._validate_columns(hf_dataset)
+
+        for processor in self._processors:
+            hf_dataset = hf_dataset.map(
+                processor,
+                batched=processor.batched,
+                batch_size=self.batch_processing_size,
+                num_proc=None,
+            )
+
+        # Padding adds a bookkeeping column; keep all rows (mirrors test split).
+        if SequencePaddingProcessor.KEEP_COLUMN_NAME in hf_dataset.column_names:
+            hf_dataset = hf_dataset.remove_columns(
+                SequencePaddingProcessor.KEEP_COLUMN_NAME
+            )
+
+        hf_dataset = hf_dataset.select_columns(self.input_columns)
+
+        feature_columns = [*self.model_features, *self._extracted_feature_names]
+        hf_dataset = cast_feature_columns_to_float(
+            hf_dataset, feature_columns, batch_size=self.batch_processing_size
+        )
+
+        if self.dataset_type == "pt":
+            return to_torch_dataloader(
+                hf_dataset, self.input_columns, batch_size=self.batch_size
+            )
+        return to_tf_tensor_dataset(
+            hf_dataset, self.input_columns, batch_size=self.batch_size
+        )
+
+    def __call__(self, inputs):
+        return self.transform(inputs)
+
+    # -------------------------------------------------------------------- helpers
+
+    def _to_hf_dataset(self, inputs) -> Dataset:
+        if isinstance(inputs, Dataset):
+            return inputs
+        if isinstance(inputs, pd.DataFrame):
+            return Dataset.from_pandas(inputs, preserve_index=False)
+        if isinstance(inputs, str):
+            return Dataset.from_dict({self.sequence_column: [inputs]})
+        if isinstance(inputs, np.ndarray):
+            return Dataset.from_dict({self.sequence_column: inputs.tolist()})
+        if isinstance(inputs, dict):
+            return Dataset.from_dict(inputs)
+        if isinstance(inputs, (list, tuple)):
+            return Dataset.from_dict({self.sequence_column: list(inputs)})
+        raise ValueError(
+            "Unsupported input type for preprocessing: "
+            f"{type(inputs)}. Provide a string, list/array of strings, dict, "
+            "pandas DataFrame, or a HuggingFace Dataset."
+        )
+
+    def _validate_columns(self, hf_dataset: Dataset) -> None:
+        if self.sequence_column not in hf_dataset.column_names:
+            raise ValueError(
+                f"Sequence column '{self.sequence_column}' not found in inputs. "
+                f"Available columns: {hf_dataset.column_names}"
+            )
+        missing = [f for f in self.model_features if f not in hf_dataset.column_names]
+        if missing:
+            raise ValueError(
+                f"Model feature column(s) {missing} required by this preprocessor are "
+                f"missing from the inputs. Available columns: {hf_dataset.column_names}"
+            )
+
+
+def _string_features(features) -> List[Union[str, Callable]]:
+    """Keep only string feature names from a possibly-mixed list (drop reprs)."""
+    if not features:
+        return []
+    return [f for f in features if isinstance(f, str)]

--- a/src/dlomix/data/ion_mobility.py
+++ b/src/dlomix/data/ion_mobility.py
@@ -63,6 +63,11 @@ class IonMobilityDataset(PeptideDataset):
         auto_cleanup_cache: bool = True,
         num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
+        split_strategy: Optional[str] = "random",
+        split_seed: Optional[int] = None,
+        test_ratio: Optional[float] = None,
+        stratify_by_column: Optional[str] = None,
+        test_uniqueness: bool = True,
     ):
         kwargs = {k: v for k, v in locals().items() if k not in ["self", "__class__"]}
         super().__init__(DatasetConfig(**kwargs))

--- a/src/dlomix/data/ion_mobility.py
+++ b/src/dlomix/data/ion_mobility.py
@@ -67,7 +67,6 @@ class IonMobilityDataset(PeptideDataset):
         split_seed: Optional[int] = None,
         test_ratio: Optional[float] = None,
         stratify_by_column: Optional[str] = None,
-        test_uniqueness: bool = True,
     ):
         kwargs = {k: v for k, v in locals().items() if k not in ["self", "__class__"]}
         super().__init__(DatasetConfig(**kwargs))

--- a/src/dlomix/data/ion_mobility.py
+++ b/src/dlomix/data/ion_mobility.py
@@ -19,7 +19,7 @@ class IonMobilityDataset(PeptideDataset):
         data_format (str): The format of the data source. Defaults to "parquet".
         sequence_column (str): The column name for the peptide sequence in the dataset. Defaults to "sequence_modified".
         label_column (str): The column name for ion mobility in the dataset. Defaults to ["ccs", "ccs_std"].
-        val_ratio (float): The ratio of validation data to split from the main dataset. Defaults to 0.2.
+        val_ratio (Optional[float]): Fraction of data for the validation split. None or 0 means no val split. Defaults to None.
         max_seq_len (Union[int, str]): The maximum sequence length allowed in the dataset. Defaults to 30.
         dataset_type (str): The type of dataset to use. Defaults to "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for the dataset. Defaults to 256.
@@ -45,7 +45,7 @@ class IonMobilityDataset(PeptideDataset):
         data_format: str = "parquet",
         sequence_column: str = "sequence_modified",
         label_column: Union[str, List] = ["ccs", "ccs_std"],
-        val_ratio: float = 0.1,
+        val_ratio: Optional[float] = None,
         max_seq_len: Union[int, str] = 50,
         dataset_type: str = "tf",
         batch_size: int = 256,

--- a/src/dlomix/data/loading.py
+++ b/src/dlomix/data/loading.py
@@ -1,0 +1,210 @@
+"""
+Resolve a dataset's data source(s) into a HuggingFace dataset and decide how splitting
+should be handled.
+
+``DataSourceLoader`` handles the three source modes (local files, HF Hub, in-memory
+HF objects), determines the :class:`_DatasetSplitMode`, and emits the user-facing
+warnings / conflict errors. ``PeptideDataset`` consumes the returned :class:`LoadResult`.
+"""
+
+import warnings
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Union
+
+from datasets import Dataset, DatasetDict, load_dataset
+
+DEFAULT_SPLIT_NAMES = ["train", "val", "test"]
+
+
+class _DatasetSplitMode(Enum):
+    AUTO = "auto"  # Single train source; run the configured splitter
+    PREDEFINED = "predefined"  # Splits defined externally; pass through as-is
+    TEST_ONLY = "test_only"  # Only a test set provided; no splitting needed
+
+
+@dataclass
+class LoadResult:
+    hf_dataset: Optional[Union[Dataset, DatasetDict]]
+    available_splits: dict
+    empty: bool
+    split_mode: Optional[_DatasetSplitMode]
+
+
+class DataSourceLoader:
+    """Load data from files / hub / in-memory and resolve the split mode."""
+
+    def __init__(self, config, hub_kwargs: Optional[dict] = None):
+        self.config = config
+        self.hub_kwargs = hub_kwargs or {}
+
+    def load(self) -> LoadResult:
+        if self.config.data_format == "hub":
+            hf_dataset, available, empty = self._load_from_hub()
+        elif self.config.data_format == "hf":
+            hf_dataset, available, empty = self._load_from_inmemory()
+        else:
+            hf_dataset, available, empty = self._load_from_files()
+
+        split_mode = self._determine_split_mode(available)
+        self._validate_and_warn(split_mode, available)
+        return LoadResult(hf_dataset, available, empty, split_mode)
+
+    # ------------------------------------------------------------------- sources
+
+    def _load_from_files(self):
+        sources = [
+            self.config.data_source,
+            self.config.val_data_source,
+            self.config.test_data_source,
+        ]
+        available = {
+            split: source
+            for split, source in zip(DEFAULT_SPLIT_NAMES, sources)
+            if source is not None
+        }
+
+        if not available:
+            warnings.warn(
+                "No data files provided, please provide at least one data source if you "
+                "plan to use this dataset directly. Otherwise, you can later load data "
+                "into this empty dataset"
+            )
+            return None, available, True
+
+        hf_dataset = load_dataset(self.config.data_format, data_files=available)
+        return hf_dataset, available, False
+
+    def _load_from_hub(self):
+        hf_dataset = load_dataset(self.config.data_source, **self.hub_kwargs)
+        warnings.warn(
+            "The provided data is assumed to be hosted on the Hugging Face Hub since "
+            'data_format is set to "hub". Validation and test data sources will be ignored.'
+        )
+
+        if isinstance(hf_dataset, DatasetDict):
+            for split in hf_dataset.keys():
+                if split not in DEFAULT_SPLIT_NAMES:
+                    raise ValueError(
+                        f"The split name {split} is not a valid split name. Please use "
+                        f"one of the default split names: {DEFAULT_SPLIT_NAMES}."
+                    )
+            available = {
+                split: f"HF hub dataset - {self.config.data_source} - {split}"
+                for split in hf_dataset
+            }
+        else:
+            available = {
+                DEFAULT_SPLIT_NAMES[0]: f"HF hub dataset - {self.config.data_source}"
+            }
+        return hf_dataset, available, False
+
+    def _load_from_inmemory(self):
+        source = self.config.data_source
+
+        if isinstance(source, DatasetDict):
+            warnings.warn(
+                'data_format="hf" with a DatasetDict: using the provided splits as-is. '
+                f"Split names must follow {DEFAULT_SPLIT_NAMES}. "
+                "val_data_source and test_data_source are ignored."
+            )
+            available = {
+                split: f"in-memory Dataset object - {split}" for split in source
+            }
+            return source, available, False
+
+        if isinstance(source, Dataset):
+            warnings.warn(
+                'data_format="hf" with a Dataset: the dataset will be automatically split '
+                "into train/val (and optionally test) according to the split configuration. "
+                "val_data_source and test_data_source are ignored."
+            )
+            hf_dataset = DatasetDict({DEFAULT_SPLIT_NAMES[0]: source})
+            available = {DEFAULT_SPLIT_NAMES[0]: "in-memory Dataset object"}
+            return hf_dataset, available, False
+
+        raise ValueError(
+            "The provided data source is not a valid Hugging Face Dataset/DatasetDict "
+            "object. The data_format value should be set to 'hf' if you plan to use an "
+            "in-memory Hugging Face Dataset/DatasetDict object."
+        )
+
+    # ------------------------------------------------------------- split decision
+
+    def _determine_split_mode(self, available: dict) -> _DatasetSplitMode:
+        # Hub datasets are always predefined: trust the hub's split structure
+        if self.config.data_format == "hub":
+            return _DatasetSplitMode.PREDEFINED
+
+        # In-memory DatasetDict is predefined by definition
+        if self.config.data_format == "hf" and isinstance(
+            self.config.data_source, DatasetDict
+        ):
+            return _DatasetSplitMode.PREDEFINED
+
+        # Multiple sources provided → all splits are already defined externally
+        if len(available) >= 2:
+            return _DatasetSplitMode.PREDEFINED
+
+        if DEFAULT_SPLIT_NAMES[2] in available:  # "test" only
+            return _DatasetSplitMode.TEST_ONLY
+
+        if DEFAULT_SPLIT_NAMES[1] in available:  # "val" only, no train
+            return _DatasetSplitMode.PREDEFINED
+
+        # Single "train" source (file or in-memory Dataset) → auto-split
+        return _DatasetSplitMode.AUTO
+
+    def _has_explicit_split_params(self) -> bool:
+        return (
+            self.config.val_ratio is not None
+            or self.config.test_ratio is not None
+            or (
+                self.config.split_strategy
+                and self.config.split_strategy.lower() != "random"
+            )
+            or self.config.stratify_by_column is not None
+        )
+
+    def _validate_and_warn(
+        self, split_mode: _DatasetSplitMode, available: dict
+    ) -> None:
+        if split_mode == _DatasetSplitMode.PREDEFINED:
+            warnings.warn(
+                f"Using provided splits as-is: {list(available.keys())}. "
+                "No automatic splitting will occur."
+            )
+        elif split_mode == _DatasetSplitMode.TEST_ONLY:
+            warnings.warn(
+                "Only a test split was provided. No automatic splitting will occur."
+            )
+
+        if split_mode != _DatasetSplitMode.AUTO and self.config.split_seed is not None:
+            warnings.warn(
+                f"split_seed={self.config.split_seed} is set but no automatic splitting "
+                "will occur (splits are predefined or only a test set was provided). "
+                "The seed is ignored."
+            )
+
+        if (
+            split_mode == _DatasetSplitMode.PREDEFINED
+            and self._has_explicit_split_params()
+        ):
+            raise ValueError(
+                "Cannot use split configuration parameters (val_ratio, test_ratio, "
+                "split_strategy, stratify_by_column) when providing predefined data "
+                f"sources. Found predefined splits: {list(available.keys())}. Either "
+                "provide only data_source for automatic splitting or provide predefined "
+                "splits without split configuration parameters."
+            )
+
+        if (
+            split_mode == _DatasetSplitMode.TEST_ONLY
+            and self._has_explicit_split_params()
+        ):
+            raise ValueError(
+                "Cannot use split configuration parameters (val_ratio, test_ratio, "
+                "split_strategy, stratify_by_column) when only test data is provided — "
+                "there is no training data to split. "
+                "Either omit the split parameters or also provide data_source."
+            )

--- a/src/dlomix/data/processing/__init__.py
+++ b/src/dlomix/data/processing/__init__.py
@@ -1,10 +1,8 @@
-import json
-
 from .feature_extractors import (
     AVAILABLE_FEATURE_EXTRACTORS,
-    FEATURE_EXTRACTORS_PARAMETERS,
     FeatureExtractor,
     LookupFeatureExtractor,
+    available_feature_extractors,
 )
 from .processors import (
     FunctionProcessor,
@@ -16,6 +14,7 @@ from .processors import (
 
 __all__ = [
     "AVAILABLE_FEATURE_EXTRACTORS",
+    "available_feature_extractors",
     "LookupFeatureExtractor",
     "FeatureExtractor",
     "FunctionProcessor",
@@ -24,27 +23,3 @@ __all__ = [
     "SequencePaddingProcessor",
     "SequencePTMRemovalProcessor",
 ]
-
-d = dict(
-    zip(
-        AVAILABLE_FEATURE_EXTRACTORS,
-        [
-            FEATURE_EXTRACTORS_PARAMETERS.get(f, {}).get("description")
-            for f in AVAILABLE_FEATURE_EXTRACTORS
-        ],
-    )
-)
-
-print(
-    f"""
-Available feature extractors are (use the key of the following dict and pass it to features_to_extract in the Dataset Class):
-{json.dumps(d, indent=3, sort_keys=True)}.
-When writing your own feature extractor, you can either
-    (1) use the FeatureExtractor class or
-    (2) write a function that can be mapped to the Hugging Face dataset.
-In both cases, you can access the parsed sequence information from the dataset using the following keys, which all provide python lists:
-    - {SequenceParsingProcessor.PARSED_COL_NAMES["seq"]}: parsed sequence
-    - {SequenceParsingProcessor.PARSED_COL_NAMES["n_term"]}: N-terminal modifications
-    - {SequenceParsingProcessor.PARSED_COL_NAMES["c_term"]}: C-terminal modifications
-"""
-)

--- a/src/dlomix/data/processing/chain.py
+++ b/src/dlomix/data/processing/chain.py
@@ -1,0 +1,158 @@
+"""
+Single source of truth for the ordered sequence-processing chain.
+
+Both the training-time :class:`~dlomix.data.processing.pipeline.ProcessingPipeline` and
+the inference-time :class:`~dlomix.data.inference.PeptidePreprocessor` build the same
+chain — parse → (PTM removal) → encode → (pad) → feature extractors — and differ only in
+how the encoding step is configured (learn-the-vocab vs frozen-vocab-with-fallback). This
+builder centralizes that construction so the two cannot drift apart.
+"""
+
+import warnings
+from typing import Callable, List, Optional, Tuple, Union
+
+from ..dataset_utils import EncodingScheme
+from .feature_extractors import (
+    AVAILABLE_FEATURE_EXTRACTORS,
+    FEATURE_EXTRACTORS_PARAMETERS,
+    LookupFeatureExtractor,
+)
+from .processors import (
+    FunctionProcessor,
+    PeptideDatasetBaseProcessor,
+    SequenceEncodingProcessor,
+    SequencePaddingProcessor,
+    SequenceParsingProcessor,
+    SequencePTMRemovalProcessor,
+)
+
+
+def build_processing_chain(
+    *,
+    sequence_column: str,
+    encoding_scheme: EncodingScheme,
+    with_termini: bool,
+    max_seq_len: int,
+    padding_value: str,
+    alphabet: dict,
+    pad: bool = True,
+    features_to_extract: Optional[List[Union[str, Callable]]] = None,
+    encoding_extend_alphabet: bool = False,
+    encoding_fallback_unmodified: bool = False,
+    warn_unmod: bool = True,
+) -> Tuple[List[PeptideDatasetBaseProcessor], List[str]]:
+    """Build the ordered processor chain and the names of extracted feature columns.
+
+    The encoding behavior is selected by the caller:
+    - training: ``encoding_extend_alphabet=learning_mode`` (per-split learn/fallback is
+      then handled by the encoder's ``apply_to_split``);
+    - inference: ``encoding_extend_alphabet=False, encoding_fallback_unmodified=True``
+      (frozen vocabulary, unseen tokens fall back to the unmodified amino acid).
+
+    Returns ``(processors, extracted_feature_names)``.
+    """
+    max_length = max_seq_len + 2 if with_termini else max_seq_len
+
+    processors: List[PeptideDatasetBaseProcessor] = [
+        SequenceParsingProcessor(
+            sequence_column, batched=True, with_termini=with_termini
+        )
+    ]
+
+    if encoding_scheme == EncodingScheme.UNMOD:
+        if warn_unmod:
+            warnings.warn(
+                f"Encoding scheme is {encoding_scheme}, this enforces removing all "
+                "occurences of PTMs in the sequences. If you prefer to encode the "
+                "(amino-acids)+PTM combinations as tokens in the vocabulary, please use "
+                "the encoding scheme 'naive-mods'."
+            )
+        processors.append(
+            SequencePTMRemovalProcessor(
+                sequence_column_name=sequence_column, batched=True
+            )
+        )
+    elif encoding_scheme != EncodingScheme.NAIVE_MODS:
+        raise NotImplementedError(
+            f"Encoding scheme {encoding_scheme} is not implemented. Available "
+            f"encoding schemes are: {list(EncodingScheme.__members__)}."
+        )
+
+    processors.append(
+        SequenceEncodingProcessor(
+            sequence_column_name=sequence_column,
+            alphabet=alphabet,
+            batched=True,
+            extend_alphabet=encoding_extend_alphabet,
+            fallback_unmodified=encoding_fallback_unmodified,
+        )
+    )
+
+    if pad:
+        processors.append(
+            SequencePaddingProcessor(
+                sequence_column_name=sequence_column,
+                batched=True,
+                padding_index=alphabet[padding_value],
+                max_length=max_length,
+            )
+        )
+    else:
+        warnings.warn(
+            "Padding is turned off, sequences will have variable lengths. Converting "
+            "this dataset to tensors will cause errors unless proper stacking of "
+            "examples is done."
+        )
+
+    feature_processors, extracted_feature_names = _build_feature_extractors(
+        features_to_extract, max_length
+    )
+    processors.extend(feature_processors)
+
+    return processors, extracted_feature_names
+
+
+def _build_feature_extractors(
+    features_to_extract, max_length
+) -> Tuple[List[PeptideDatasetBaseProcessor], List[str]]:
+    processors: List[PeptideDatasetBaseProcessor] = []
+    names: List[str] = []
+    if not features_to_extract:
+        return processors, names
+
+    for feature in features_to_extract:
+        if isinstance(feature, str):
+            feature_name = feature.lower()
+            if feature_name not in AVAILABLE_FEATURE_EXTRACTORS:
+                warnings.warn(
+                    f"Skipping feature extractor {feature} since it is not available. "
+                    f"Please choose from: {AVAILABLE_FEATURE_EXTRACTORS}."
+                )
+                continue
+            processors.append(
+                LookupFeatureExtractor(
+                    sequence_column_name=SequenceParsingProcessor.PARSED_COL_NAMES[
+                        "seq"
+                    ],
+                    feature_column_name=feature_name,
+                    **FEATURE_EXTRACTORS_PARAMETERS[feature_name],
+                    max_length=max_length,
+                    batched=True,
+                )
+            )
+        elif callable(feature):
+            warnings.warn(
+                f"Using custom feature extractor from the user function "
+                f"{feature.__name__}; please ensure it pads the feature to the "
+                "sequence length so all tensors share the sequence-length dimension."
+            )
+            feature_name = feature.__name__
+            processors.append(FunctionProcessor(feature))
+        else:
+            raise ValueError(
+                f"Feature extractor {feature} is not a valid type. Provide a function "
+                "or a string naming a valid feature extractor."
+            )
+        names.append(feature_name)
+
+    return processors, names

--- a/src/dlomix/data/processing/feature_extractors.py
+++ b/src/dlomix/data/processing/feature_extractors.py
@@ -1,3 +1,24 @@
+"""
+Feature extractors that compute per-residue/per-sequence features from parsed peptides.
+
+Pass built-in feature names to a dataset via ``features_to_extract``; call
+:func:`available_feature_extractors` to discover them. To add your own feature, either:
+
+1. subclass :class:`FeatureExtractor`, or
+2. write a function and pass it in ``features_to_extract`` (it is wrapped in a
+   ``FunctionProcessor`` and mapped over the HuggingFace dataset).
+
+In both cases you can read the parsed sequence information from each row via the keys
+exposed in ``SequenceParsingProcessor.PARSED_COL_NAMES``:
+
+- ``_parsed_sequence``: the parsed sequence (list of amino-acid + PTM tokens)
+- ``_n_term_mods``: N-terminal modifications
+- ``_c_term_mods``: C-terminal modifications
+
+A custom function must return the row with the new feature column added, and must pad the
+feature to the sequence length so all tensors share the sequence-length dimension.
+"""
+
 from collections import defaultdict
 from operator import itemgetter
 
@@ -46,6 +67,18 @@ FEATURE_EXTRACTORS_PARAMETERS = {
 }
 
 AVAILABLE_FEATURE_EXTRACTORS = list(FEATURE_EXTRACTORS_PARAMETERS.keys())
+
+
+def available_feature_extractors() -> dict:
+    """Return a ``{name: description}`` mapping of the built-in feature extractors.
+
+    Use any of the returned names in a dataset's ``features_to_extract``. See this
+    module's docstring for how to write a custom feature extractor.
+    """
+    return {
+        name: params.get("description")
+        for name, params in FEATURE_EXTRACTORS_PARAMETERS.items()
+    }
 
 
 class FeatureExtractor(PeptideDatasetBaseProcessor):

--- a/src/dlomix/data/processing/pipeline.py
+++ b/src/dlomix/data/processing/pipeline.py
@@ -1,0 +1,111 @@
+"""
+Build and apply the ordered sequence-processing pipeline for a peptide dataset.
+
+``ProcessingPipeline`` turns the dataset configuration into an ordered list of
+processors (parse → optional PTM removal → encode → optional pad → feature extractors)
+and applies them across the dataset's splits. Per-split behavior (learn-then-apply
+encoding, dropping truncated rows) lives on the processors themselves via
+``apply_to_split``; the pipeline just iterates, keeping it open for extension.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Union
+
+from ..dataset_utils import EncodingScheme
+from .chain import build_processing_chain
+from .processors import (
+    PeptideDatasetBaseProcessor,
+    SequencePaddingProcessor,
+    SequenceParsingProcessor,
+)
+
+DEFAULT_SPLIT_NAMES = ["train", "val", "test"]
+
+
+@dataclass
+class PipelineContext:
+    """Mutable state shared with processors while applying the pipeline.
+
+    ``alphabet`` is updated in place by the encoding processor as it learns the
+    vocabulary on the fit splits; the dataset reads it back afterwards.
+    """
+
+    alphabet: dict
+    num_proc: Optional[int]
+    batch_size: int
+    fit_splits: tuple
+
+
+class ProcessingPipeline:
+    """An ordered list of processors plus the columns they introduce."""
+
+    def __init__(
+        self,
+        processors: List[PeptideDatasetBaseProcessor],
+        extracted_feature_names: List[str],
+        split_names: Optional[List[str]] = None,
+    ):
+        self.processors = processors
+        self.extracted_feature_names = extracted_feature_names
+        self.split_names = split_names or DEFAULT_SPLIT_NAMES
+
+    @property
+    def parsed_columns(self) -> List[str]:
+        """Columns added by sequence parsing (kept in the HF dataset, not tensorized)."""
+        return list(SequenceParsingProcessor.PARSED_COL_NAMES.values())
+
+    @classmethod
+    def from_config(
+        cls,
+        sequence_column: str,
+        encoding_scheme: EncodingScheme,
+        with_termini: bool,
+        max_seq_len: int,
+        padding_value: str,
+        alphabet: dict,
+        learning_alphabet_mode: bool,
+        pad: bool,
+        features_to_extract: Optional[List[Union[str, Callable]]] = None,
+        split_names: Optional[List[str]] = None,
+    ) -> "ProcessingPipeline":
+        # training-time encoding: learn/extend the vocabulary on the fit splits
+        # (per-split learn vs fallback is handled by the encoder's apply_to_split)
+        processors, extracted_feature_names = build_processing_chain(
+            sequence_column=sequence_column,
+            encoding_scheme=encoding_scheme,
+            with_termini=with_termini,
+            max_seq_len=max_seq_len,
+            padding_value=padding_value,
+            alphabet=alphabet,
+            pad=pad,
+            features_to_extract=features_to_extract,
+            encoding_extend_alphabet=learning_alphabet_mode,
+        )
+        return cls(processors, extracted_feature_names, split_names)
+
+    def apply(self, hf_dataset, ctx: PipelineContext):
+        """Apply every processor across all splits and drop the padding bookkeeping column."""
+        for processor in self.processors:
+            for split in self._split_order(hf_dataset, processor):
+                hf_dataset[split] = processor.apply_to_split(
+                    hf_dataset[split], split, ctx
+                )
+
+        first_split = next(iter(hf_dataset))
+        if (
+            SequencePaddingProcessor.KEEP_COLUMN_NAME
+            in hf_dataset[first_split].column_names
+        ):
+            hf_dataset = hf_dataset.remove_columns(
+                SequencePaddingProcessor.KEEP_COLUMN_NAME
+            )
+
+        return hf_dataset
+
+    def _split_order(self, hf_dataset, processor) -> List[str]:
+        splits = list(hf_dataset.keys())
+        if not processor.requires_ordered_splits:
+            return splits
+        # fit splits (train/val) before eval (test) so the vocab is learned first
+        ordered = [s for s in self.split_names if s in hf_dataset]
+        return ordered + [s for s in splits if s not in ordered]

--- a/src/dlomix/data/processing/processors.py
+++ b/src/dlomix/data/processing/processors.py
@@ -15,6 +15,10 @@ class PeptideDatasetBaseProcessor(abc.ABC):
         Whether to process data in batches.
     """
 
+    # Whether the pipeline must apply this processor to the fit splits (train/val)
+    # before the eval split (test) — e.g. to learn a vocabulary first.
+    requires_ordered_splits = False
+
     def __init__(self, sequence_column_name: str = "", batched: bool = False):
         self.sequence_column_name = sequence_column_name
         self.batched = batched
@@ -29,6 +33,26 @@ class PeptideDatasetBaseProcessor(abc.ABC):
 
     def __call__(self, input_data, **kwargs):
         return self.process(input_data, **kwargs)
+
+    def apply_to_split(self, dataset, split, ctx):
+        """Apply this processor to a single split and return the new dataset.
+
+        Default is a uniform ``.map()``. Processors with split-specific behavior
+        (learn-then-apply, dropping truncated rows, ...) override this instead of the
+        pipeline special-casing them. ``ctx`` is a ``PipelineContext`` carrying
+        ``num_proc``, ``batch_size``, the (mutable) learned ``alphabet`` and the
+        ``fit_splits`` names.
+        """
+        return dataset.map(
+            self,
+            desc=f"Mapping {self._map_description()} on split {split}",
+            batched=self.batched,
+            batch_size=ctx.batch_size,
+            num_proc=ctx.num_proc,
+        )
+
+    def _map_description(self) -> str:
+        return self.__class__.__name__
 
     def __repr__(self):
         members = [
@@ -208,6 +232,28 @@ class SequencePaddingProcessor(PeptideDatasetBaseProcessor):
         self.padding_index = padding_index
         self.max_length = max_length
 
+    def apply_to_split(self, dataset, split, ctx):
+        # pad all splits; drop sequences truncated to max_length only on the fit
+        # splits (train/val) — the test split keeps every row for evaluation
+        result = super().apply_to_split(dataset, split, ctx)
+        if split in ctx.fit_splits:
+            n_before = len(result)
+            result = result.filter(
+                lambda batch: batch[self.KEEP_COLUMN_NAME],
+                batched=True,
+                num_proc=ctx.num_proc,
+                batch_size=ctx.batch_size,
+            )
+            n_dropped = n_before - len(result)
+            if n_dropped:
+                warnings.warn(
+                    f"Dropped {n_dropped} sequence(s) from split '{split}' that exceed "
+                    "the maximum sequence length; truncated sequences are removed from "
+                    "train/val (they are retained in a test split). Increase max_seq_len "
+                    "to keep them."
+                )
+        return result
+
     def batch_process(self, input_data, **kwargs):
         input_data[SequencePaddingProcessor.KEEP_COLUMN_NAME] = [True] * len(
             input_data[self.sequence_column_name]
@@ -259,6 +305,41 @@ class SequenceEncodingProcessor(PeptideDatasetBaseProcessor):
     fallback_unmodified : bool (default=False)
         Whether to fallback to unmodified amino acid encoding for unseen modifications.
     """
+
+    # learn the vocabulary on train/val before encoding the test split
+    requires_ordered_splits = True
+
+    def apply_to_split(self, dataset, split, ctx):
+        if split in ctx.fit_splits:
+            # learn/extend the alphabet on the fit splits; force single-process while
+            # learning so the vocabulary is built over the whole split, not a shard
+            single_process = bool(self.extend_alphabet)
+            result = dataset.map(
+                self,
+                desc=f"Mapping {self._map_description()} on split {split}",
+                batched=self.batched,
+                batch_size=ctx.batch_size,
+                num_proc=None if single_process else ctx.num_proc,
+            )
+            ctx.alphabet = self.alphabet.copy()
+            return result
+
+        # eval split(s): encode with the learned alphabet, falling back to the
+        # unmodified amino acid for unseen (AA, PTM) combinations
+        eval_processor = SequenceEncodingProcessor(
+            sequence_column_name=self.sequence_column_name,
+            alphabet=ctx.alphabet,
+            batched=self.batched,
+            extend_alphabet=False,
+            fallback_unmodified=True,
+        )
+        return dataset.map(
+            eval_processor,
+            desc=f"Mapping {eval_processor._map_description()} on split {split}",
+            batched=self.batched,
+            batch_size=ctx.batch_size,
+            num_proc=ctx.num_proc,
+        )
 
     def __init__(
         self,
@@ -421,6 +502,9 @@ class FunctionProcessor(PeptideDatasetBaseProcessor):
         super().__init__(batched=False)
         self.function = function
         self.name = name if name != "" else self.function.__name__
+
+    def _map_description(self) -> str:
+        return f"{self.__class__.__name__} (function name: {self.function.__name__})"
 
     def batch_process(self, input_data, **kwargs):
         raise NotImplementedError("FunctionProcessor does not support batch processing")

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -16,7 +16,7 @@ class RetentionTimeDataset(PeptideDataset):
         data_format (str): The format of the data source. Defaults to "parquet".
         sequence_column (str): The column name for the peptide sequence in the dataset. Defaults to "modified_sequence".
         label_column (str): The column name for the retention time label in the dataset. Defaults to "indexed_retention_time".
-        val_ratio (float): The ratio of validation data to split from the main dataset. Defaults to 0.2.
+        val_ratio (Optional[float]): Fraction of data for the validation split. None or 0 means no val split. Defaults to None.
         max_seq_len (Union[int, str]): The maximum sequence length allowed in the dataset. Defaults to 30.
         dataset_type (str): The type of dataset to use. Defaults to "tf". Fallback is to TensorFlow dataset tensors.
         batch_size (int): The batch size for the dataset. Defaults to 256.
@@ -50,7 +50,7 @@ class RetentionTimeDataset(PeptideDataset):
         data_format: str = "parquet",
         sequence_column: str = "modified_sequence",
         label_column: str = "indexed_retention_time",
-        val_ratio: float = 0.2,
+        val_ratio: Optional[float] = None,
         max_seq_len: Union[int, str] = 30,
         dataset_type: str = "tf",
         batch_size: int = 256,

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -36,6 +36,11 @@ class RetentionTimeDataset(PeptideDataset):
         num_proc (Optional[int]): Number of processes to use for dataset processing. Use -1 for all available processors, None for single-process mode, or a positive integer. Default is -1.
         batch_processing_size (int): Size of batches for processing. Default is 1000.
         torch_dataloader_kwargs (Optional[Dict]): Additional keyword arguments to pass to PyTorch DataLoader. Default is None.
+        split_strategy (Optional[str]): Strategy for splitting the dataset. Options: 'random', 'sequence_unique', 'stratified'. Default is 'random'.
+        split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
+        test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
+        stratify_by_column (Optional[str]): Column name for stratified splitting. Can be a label column or feature column. Default is None.
+        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -66,6 +71,12 @@ class RetentionTimeDataset(PeptideDataset):
         num_proc: Optional[int] = -1,
         batch_processing_size: int = 1000,
         torch_dataloader_kwargs: Optional[Dict] = None,
+        # New splitting parameters
+        split_strategy: Optional[str] = "random",
+        split_seed: Optional[int] = None,
+        test_ratio: Optional[float] = None,
+        stratify_by_column: Optional[str] = None,
+        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/retention_time.py
+++ b/src/dlomix/data/retention_time.py
@@ -40,7 +40,6 @@ class RetentionTimeDataset(PeptideDataset):
         split_seed (Optional[int]): Random seed for reproducible splits. Default is None.
         test_ratio (Optional[float]): Ratio of test data for three-way splits. If None, only train/val split is performed. Default is None.
         stratify_by_column (Optional[str]): Column name for stratified splitting. Can be a label column or feature column. Default is None.
-        test_uniqueness (bool): When using split_strategy='sequence_unique', ensures test sequences are unique from train/val. Default is True.
     """
 
     def __init__(
@@ -76,7 +75,6 @@ class RetentionTimeDataset(PeptideDataset):
         split_seed: Optional[int] = None,
         test_ratio: Optional[float] = None,
         stratify_by_column: Optional[str] = None,
-        test_uniqueness: bool = True,
         **kwargs,
     ):
         config_kwargs = {

--- a/src/dlomix/data/serialization.py
+++ b/src/dlomix/data/serialization.py
@@ -1,0 +1,154 @@
+"""
+Persistence for processed peptide datasets: serialize runtime state, save to disk,
+and reconstruct the correct subclass on load.
+
+Operates on a ``PeptideDataset`` instance via its public attributes/constants, so it
+carries no hard import of the dataset class (``load_processed_dataset`` imports it lazily).
+"""
+
+import importlib
+import json
+from pathlib import Path
+
+from .dataset_config import DatasetConfig
+
+# Transient / non-reconstructable attributes excluded from the saved state.
+_STATE_EXCLUDE = {
+    "hf_dataset",
+    "_config",
+    "data_source",
+    "_split_mode",
+    "_temp_stratify_column",
+}
+
+
+def build_serializable_state(dataset) -> dict:
+    """Collect the dataset's runtime attributes as a JSON-serializable dict."""
+    state = {}
+    for key, value in dataset.__dict__.items():
+        if key in _STATE_EXCLUDE:
+            continue
+        try:
+            json.dumps(value)
+            state[key] = value
+        except (TypeError, ValueError):
+            # keep containers as-is (their items round-trip); stringify other objects
+            if isinstance(value, dict):
+                state[key] = value
+            elif isinstance(value, (list, tuple, set)):
+                state[key] = list(value)
+            else:
+                state[key] = str(type(value))
+    return state
+
+
+def save_dataset(dataset, path: str, overwrite: bool = False) -> bool:
+    """Save config, runtime-state metadata, and the HF dataset to ``path``."""
+    path_obj = Path(path)
+    if path_obj.exists() and not overwrite:
+        raise FileExistsError(
+            f"Directory {path} already exists. Set overwrite=True to overwrite and "
+            "replace the saved dataset."
+        )
+    path_obj.mkdir(parents=True, exist_ok=True)
+
+    # original config (input parameters as provided by the user)
+    dataset._config.save_config_json(str(path_obj / dataset.CONFIG_JSON_NAME))
+
+    metadata = {
+        "class_name": type(dataset).__name__,
+        "module_name": type(dataset).__module__,
+        "state": build_serializable_state(dataset),
+        "version": dataset.SERIALIZATION_VERSION,
+    }
+    (path_obj / dataset.METADATA_JSON_NAME).write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )
+
+    if dataset.hf_dataset is not None:
+        dataset.hf_dataset.save_to_disk(str(path_obj / "hf_dataset"))
+
+    return True
+
+
+def validate_loaded_state(dataset) -> None:
+    """Raise ValueError if a freshly loaded dataset is inconsistent."""
+    if getattr(dataset, "hf_dataset", None) is None:
+        raise ValueError("HuggingFace dataset not loaded properly.")
+
+    if not dataset.processed:
+        raise ValueError("Dataset should be marked as processed after loading.")
+
+    if hasattr(dataset, "_relevant_columns"):
+        expected_columns = set(dataset._relevant_columns)
+        for split in dataset.hf_dataset.keys():
+            dataset_columns = set(dataset.hf_dataset[split].column_names)
+            if not expected_columns.issubset(dataset_columns):
+                missing = expected_columns - dataset_columns
+                raise ValueError(
+                    f"Split '{split}' is missing expected columns: {missing}"
+                )
+
+
+def load_processed_dataset(path: str, validate: bool = True):
+    """
+    Load a processed peptide dataset from a given path.
+
+    Parameters
+    ----------
+    path : str
+        Path to the peptide dataset.
+    validate : bool, optional
+        Whether to validate the loaded dataset state, by default True.
+
+    Returns
+    -------
+    dlomix.data.PeptideDataset or one of its child classes
+        Peptide dataset.
+    """
+    from .dataset import PeptideDataset  # local import to avoid a cycle
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(
+            f"Provided directory for loading the dataset: {path} does not exist."
+        )
+
+    config = DatasetConfig.load_config_json(
+        str(path_obj / PeptideDataset.CONFIG_JSON_NAME)
+    )
+
+    metadata_path = path_obj / PeptideDataset.METADATA_JSON_NAME
+    metadata = (
+        json.loads(metadata_path.read_text(encoding="utf-8"))
+        if metadata_path.exists()
+        else None
+    )
+
+    # reconstruct the correct subclass recorded at save time
+    module = importlib.import_module("dlomix.data")
+    class_name = (
+        metadata.get("class_name", "PeptideDataset") if metadata else "PeptideDataset"
+    )
+    cls = getattr(module, class_name)
+
+    # processed=True skips re-processing during construction
+    config.processed = True
+    instance = cls.from_dataset_config(config)
+    instance._config.processed = False
+    instance.processed = True
+
+    if metadata:
+        for key, value in metadata["state"].items():
+            setattr(instance, key, value)
+
+    hf_dataset_path = path_obj / "hf_dataset"
+    if hf_dataset_path.exists():
+        from datasets import load_from_disk
+
+        instance.hf_dataset = load_from_disk(str(hf_dataset_path))
+
+    if validate:
+        validate_loaded_state(instance)
+
+    return instance

--- a/src/dlomix/data/tensor_conversion.py
+++ b/src/dlomix/data/tensor_conversion.py
@@ -1,0 +1,95 @@
+"""
+Shared helpers to convert a processed HuggingFace ``Dataset`` into backend tensors.
+
+These are used both by :class:`~dlomix.data.dataset.PeptideDataset` (per split, with
+labels) and by :class:`~dlomix.data.inference.PeptidePreprocessor` (inference, no
+labels). Kept free of dlomix-internal imports to avoid circular dependencies.
+"""
+
+from typing import Iterable, List, Optional, Union
+
+from datasets import Dataset, Sequence, Value
+
+
+def cast_feature_columns_to_float(
+    dataset: Dataset,
+    feature_columns: Iterable[str],
+    num_proc: Optional[int] = None,
+    batch_size: int = 1000,
+) -> Dataset:
+    """Cast the given feature columns (and nested sequences) to float32.
+
+    Model feature/extracted columns must be float for concatenation in the model.
+    Operates on a single ``Dataset`` and returns the cast dataset.
+    """
+
+    def cast_to_float(feature):
+        if isinstance(feature, Sequence):
+            return Sequence(cast_to_float(feature.feature))
+        if isinstance(feature, Value):
+            return Value("float32")
+        return feature
+
+    feature_columns = set(feature_columns)
+    if not feature_columns:
+        return dataset
+
+    new_features = dataset.features.copy()
+    for name, ftype in dataset.features.items():
+        if name in feature_columns:
+            new_features[name] = cast_to_float(ftype)
+
+    return dataset.cast(new_features, num_proc=num_proc, batch_size=batch_size)
+
+
+def to_tf_tensor_dataset(
+    hf_dataset: Dataset,
+    input_columns: List[str],
+    batch_size: int,
+    label_cols: Optional[Union[str, List[str]]] = None,
+    shuffle: bool = False,
+):
+    """Build a ``tf.data.Dataset`` from a processed HF dataset.
+
+    When ``label_cols`` is None, only input tensors are produced (inference).
+    A single-element label list is collapsed to a scalar column for API stability.
+    """
+    kwargs = {"columns": input_columns, "shuffle": shuffle, "batch_size": batch_size}
+
+    if label_cols is not None:
+        if isinstance(label_cols, list) and len(label_cols) == 1:
+            label_cols = label_cols[0]
+        kwargs["label_cols"] = label_cols
+
+    return hf_dataset.to_tf_dataset(**kwargs)
+
+
+def to_torch_dataloader(
+    hf_dataset: Dataset,
+    input_columns: List[str],
+    batch_size: int,
+    label_cols: Optional[List[str]] = None,
+    shuffle: bool = False,
+    dataloader_kwargs: Optional[dict] = None,
+):
+    """Build a torch ``DataLoader`` from a processed HF dataset.
+
+    When ``label_cols`` is None, only input columns are formatted (inference).
+    ``dataloader_kwargs`` (excluding ``dataset``) override the defaults.
+    """
+    from torch.utils.data import DataLoader
+
+    columns = list(input_columns)
+    if label_cols:
+        columns = [*columns, *label_cols]
+
+    kwargs = {
+        "dataset": hf_dataset.with_format(type="torch", columns=columns),
+        "batch_size": batch_size,
+        "shuffle": shuffle,
+    }
+
+    if dataloader_kwargs:
+        kwargs.update({k: v for k, v in dataloader_kwargs.items() if k != "dataset"})
+
+    return DataLoader(**kwargs)

--- a/src/dlomix/pipelines/__init__.py
+++ b/src/dlomix/pipelines/__init__.py
@@ -1,3 +1,11 @@
-from .pipeline import RetentionTimePipeline
+from .predictor import InferencePipeline
 
-__all__ = ["RetentionTimePipeline"]
+__all__ = ["InferencePipeline"]
+
+# Legacy TF-only pipeline; keep importable where its dependencies resolve.
+try:
+    from .pipeline import RetentionTimePipeline
+
+    __all__.append("RetentionTimePipeline")
+except Exception:
+    pass

--- a/src/dlomix/pipelines/predictor.py
+++ b/src/dlomix/pipelines/predictor.py
@@ -1,0 +1,264 @@
+"""
+Bundle a trained model with its preprocessor for one-call inference (HF-style).
+
+``InferencePipeline`` ties a model together with the
+:class:`~dlomix.data.inference.PeptidePreprocessor` that reproduces its training-time
+preprocessing, so users can ``predict`` directly on raw sequences and ``save``/``load``
+both as a single artifact. Backend (TensorFlow/PyTorch) is selected at import time via
+``DLOMIX_BACKEND`` (see :mod:`dlomix.config`).
+"""
+
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+from ..config import _BACKEND, PYTORCH_BACKEND
+from ..data.inference import PeptidePreprocessor
+
+_IS_TORCH = _BACKEND in PYTORCH_BACKEND
+
+PIPELINE_META_NAME = "dlomix_inference_pipeline.json"
+TF_MODEL_FILE = "model.keras"
+TORCH_MODEL_FILE = "model.pt"
+
+
+def _model_vocab_size(model):
+    """Best-effort read of a model's embedding vocab size (None if unavailable)."""
+    embedding = getattr(model, "embedding", None)
+    if embedding is None:
+        return None
+    if hasattr(embedding, "input_dim"):  # tf.keras.layers.Embedding
+        return embedding.input_dim
+    if hasattr(embedding, "num_embeddings"):  # torch.nn.Embedding
+        return embedding.num_embeddings
+    return None
+
+
+class InferencePipeline:
+    """A model + its preprocessor, with a single ``predict`` and combined save/load.
+
+    Parameters
+    ----------
+    model :
+        A trained dlomix model (TensorFlow or PyTorch, matching the active backend).
+    preprocessor : PeptidePreprocessor
+        The preprocessor reproducing the model's training-time preprocessing.
+    """
+
+    def __init__(self, model, preprocessor: PeptidePreprocessor):
+        self.model = model
+        self.preprocessor = preprocessor
+        self._check_model_consistency()
+
+    @classmethod
+    def from_model_and_dataset(cls, model, dataset) -> "InferencePipeline":
+        """Bundle a model with the preprocessor derived from a processed dataset."""
+        return cls(model, dataset.get_preprocessor())
+
+    def _check_model_consistency(self) -> None:
+        model_vocab = _model_vocab_size(self.model)
+        if model_vocab is not None and model_vocab != self.preprocessor.vocab_size:
+            raise ValueError(
+                f"Model/preprocessor mismatch: the model's embedding vocabulary size is "
+                f"{model_vocab}, but the preprocessor alphabet has "
+                f"{self.preprocessor.vocab_size} tokens. They were likely not trained "
+                f"together."
+            )
+
+    def predict(self, inputs, **predict_kwargs) -> np.ndarray:
+        """Preprocess raw inputs and run the model, returning a numpy array."""
+        tensors = self.preprocessor(inputs)
+
+        if _IS_TORCH:
+            return self._predict_torch(tensors)
+        return np.asarray(self.model.predict(tensors, **predict_kwargs))
+
+    def _predict_torch(self, loader) -> np.ndarray:
+        import torch
+
+        single_input = len(self.preprocessor.input_columns) == 1
+        seq_column = self.preprocessor.input_columns[0]
+
+        self.model.eval()
+        outputs = []
+        with torch.no_grad():
+            for batch in loader:
+                model_input = batch[seq_column] if single_input else batch
+                out = self.model(model_input)
+                outputs.append(out.detach().cpu().numpy())
+        return np.concatenate(outputs, axis=0)
+
+    def save(self, path: str, overwrite: bool = False) -> str:
+        """Save the preprocessor + model + pipeline metadata to a directory."""
+        path_obj = Path(path)
+        if path_obj.exists() and any(path_obj.iterdir()) and not overwrite:
+            raise FileExistsError(
+                f"Directory {path} already exists and is not empty. "
+                f"Set overwrite=True to replace it."
+            )
+        path_obj.mkdir(parents=True, exist_ok=True)
+
+        self.preprocessor.save(str(path_obj))
+
+        if _IS_TORCH:
+            import torch
+
+            # full-object pickle; loading executes code. TODO: state_dict + safetensors
+            # (with stored init-config) for safer sharing of public Hub repos.
+            torch.save(self.model, str(path_obj / TORCH_MODEL_FILE))
+        else:
+            # .keras format reloads registered models as their original class
+            self.model.save(str(path_obj / TF_MODEL_FILE))
+
+        meta = {
+            "backend": "pytorch" if _IS_TORCH else "tensorflow",
+            "model_class": type(self.model).__name__,
+            "fingerprint": self.preprocessor.fingerprint,
+            "vocab_size": self.preprocessor.vocab_size,
+        }
+        (path_obj / PIPELINE_META_NAME).write_text(
+            json.dumps(meta, indent=2), encoding="utf-8"
+        )
+        return str(path_obj)
+
+    @classmethod
+    def load(cls, path: str) -> "InferencePipeline":
+        """Load a bundled model + preprocessor saved with :meth:`save`."""
+        path_obj = Path(path)
+        meta = json.loads((path_obj / PIPELINE_META_NAME).read_text(encoding="utf-8"))
+
+        saved_backend = meta.get("backend")
+        current_backend = "pytorch" if _IS_TORCH else "tensorflow"
+        if saved_backend and saved_backend != current_backend:
+            raise ValueError(
+                f"Pipeline was saved with the '{saved_backend}' backend but the active "
+                f"backend is '{current_backend}'. Set DLOMIX_BACKEND={saved_backend} "
+                f"before importing dlomix."
+            )
+
+        preprocessor = PeptidePreprocessor.load(str(path_obj))
+
+        if meta.get("fingerprint") and meta["fingerprint"] != preprocessor.fingerprint:
+            warnings.warn(
+                "Loaded preprocessor fingerprint does not match the one recorded when "
+                "the pipeline was saved; preprocessing may differ from training."
+            )
+
+        if _IS_TORCH:
+            import torch
+
+            model = torch.load(str(path_obj / TORCH_MODEL_FILE), weights_only=False)
+        else:
+            import tensorflow as tf
+
+            model = tf.keras.models.load_model(str(path_obj / TF_MODEL_FILE))
+
+        return cls(model, preprocessor)
+
+    # ----------------------------------------------------------- HuggingFace Hub
+
+    def push_to_hub(
+        self,
+        repo_id: str,
+        token: str = None,
+        private: bool = False,
+        commit_message: str = "Upload dlomix inference pipeline",
+    ) -> str:
+        """Push the bundled model + preprocessor to a HuggingFace Hub repo.
+
+        The repo holds the same files as :meth:`save` (preprocessor, model, metadata)
+        plus an auto-generated model card. Returns the repo id.
+        """
+        import tempfile
+
+        from huggingface_hub import HfApi, create_repo
+
+        create_repo(repo_id, token=token, private=private, exist_ok=True)
+        with tempfile.TemporaryDirectory() as tmp:
+            self.save(tmp, overwrite=True)
+            self._write_model_card(tmp, repo_id)
+            HfApi(token=token).upload_folder(
+                repo_id=repo_id,
+                folder_path=tmp,
+                commit_message=commit_message,
+                # mirror the repo to the bundle: drop any stale files from prior pushes
+                delete_patterns="*",
+            )
+        return repo_id
+
+    @classmethod
+    def from_pretrained(
+        cls, repo_id: str, token: str = None, revision: str = None, **snapshot_kwargs
+    ) -> "InferencePipeline":
+        """Load a pipeline previously pushed with :meth:`push_to_hub`."""
+        from huggingface_hub import snapshot_download
+
+        local_dir = snapshot_download(
+            repo_id=repo_id, token=token, revision=revision, **snapshot_kwargs
+        )
+        return cls.load(local_dir)
+
+    def _write_model_card(self, directory: str, repo_id: str) -> None:
+        backend = "pytorch" if _IS_TORCH else "tensorflow"
+        prep = self.preprocessor
+        predict_block = self._usage_predict_block(prep)
+
+        notes = []
+        if prep.model_features:
+            cols = ", ".join(f"`{f}`" for f in prep.model_features)
+            notes.append(
+                f"This model requires the feature column(s) {cols} to be provided "
+                f"alongside the sequences at inference time."
+            )
+        if prep.extracted_feature_names:
+            cols = ", ".join(f"`{f}`" for f in prep.extracted_feature_names)
+            notes.append(
+                f"The feature(s) {cols} are computed from the sequence automatically — "
+                f"you do not supply them."
+            )
+        features_note = ("\n\n" + "\n\n".join(notes)) if notes else ""
+
+        card = f"""---
+tags:
+- dlomix
+- proteomics
+library_name: dlomix
+---
+
+# {repo_id}
+
+A [DLOmix](https://github.com/wilhelm-lab/dlomix) inference pipeline bundling a
+`{type(self.model).__name__}` model with its `PeptidePreprocessor`.
+
+- Backend: **{backend}**
+- Vocabulary size: {prep.vocab_size}
+- Preprocessor fingerprint: `{prep.fingerprint}`{features_note}
+
+## Usage
+
+```python
+from dlomix.pipelines import InferencePipeline
+
+pipeline = InferencePipeline.from_pretrained("{repo_id}")
+predictions = {predict_block}
+```
+
+> Load under the same `DLOMIX_BACKEND` ({backend}) used when the pipeline was saved.
+"""
+        (Path(directory) / "README.md").write_text(card, encoding="utf-8")
+
+    @staticmethod
+    def _usage_predict_block(prep) -> str:
+        """Build a predict() example matching the model's required inputs."""
+        example_seqs = '["PEPTIDEK", "ACDEM[UNIMOD:35]K"]'
+        if not prep.model_features:
+            # sequence-only model: a plain list of sequences is enough
+            return f"pipeline.predict({example_seqs})"
+
+        # metadata model: inputs must be a dict of sequence + feature columns
+        lines = [f'    "{prep.sequence_column}": {example_seqs},']
+        for feat in prep.model_features:
+            lines.append(f'    "{feat}": [...],  # one entry per sequence')
+        return "pipeline.predict({\n" + "\n".join(lines) + "\n})"

--- a/tests/test_dataset_splitter.py
+++ b/tests/test_dataset_splitter.py
@@ -306,6 +306,48 @@ class TestStratifiedSplitter:
         assert "train" in result and "val" in result
         assert len(result["train"]) + len(result["val"]) == len(dataset)
 
+    def test_stratified_on_one_hot_list_column(self):
+        """A one-hot/list column is stratified on its exact value; temp key is dropped."""
+        import warnings
+
+        from datasets import Dataset
+
+        labels = [i % 3 for i in range(120)]
+        one_hot = [[1 if j == c else 0 for j in range(6)] for c in labels]
+        dataset = Dataset.from_dict(
+            {"sequence": [f"PEP{i}" for i in range(120)], "label": one_hot}
+        )
+
+        config = SplitConfig(
+            val_ratio=0.25, strategy="stratified", stratify_column="label", seed=42
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = create_splitter(config).split(dataset)
+
+        assert any("list/vector column" in str(w.message) for w in caught)
+        # all rows accounted for, no leaked temp key column
+        assert len(result["train"]) + len(result["val"]) == len(dataset)
+        for split in result.values():
+            assert "_stratify_key" not in split.column_names
+            assert "label" in split.column_names
+
+    def test_stratified_too_few_members_raises_clear_error(self):
+        """A class with a single member raises an actionable error, not the raw HF one."""
+        from datasets import Dataset
+
+        # class 2 appears exactly once -> cannot be stratified
+        labels = [0] * 50 + [1] * 49 + [2]
+        one_hot = [[1 if j == c else 0 for j in range(3)] for c in labels]
+        dataset = Dataset.from_dict(
+            {"sequence": [f"PEP{i}" for i in range(100)], "label": one_hot}
+        )
+        config = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label", seed=42
+        )
+        with pytest.raises(ValueError, match="too few members"):
+            create_splitter(config).split(dataset)
+
     def test_stratified_reproducibility(self, imbalanced_dataset):
         """Test reproducibility of stratified splits."""
         config1 = SplitConfig(

--- a/tests/test_dataset_splitter.py
+++ b/tests/test_dataset_splitter.py
@@ -1,0 +1,467 @@
+"""
+Tests for dataset splitting strategies.
+
+This module contains comprehensive tests for the dataset splitter functionality,
+including all splitting strategies, backward compatibility, edge cases, and
+reproducibility checks.
+"""
+
+import logging
+
+import pytest
+from datasets import Dataset
+
+from dlomix.data import SplitConfig, SplitStrategy, create_splitter
+from dlomix.data.dataset_splitter import (
+    RandomSplitter,
+    SequenceUniqueSplitter,
+    StratifiedSplitter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Fixtures
+@pytest.fixture
+def simple_dataset():
+    """Create a simple dataset for testing."""
+    data = {
+        "sequence": [f"PEPTIDE{i}" for i in range(100)],
+        "label": [i % 3 for i in range(100)],  # 3 classes for stratification
+        "feature": [float(i) for i in range(100)],
+    }
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def duplicate_sequence_dataset():
+    """Create a dataset with duplicate sequences."""
+    sequences = [
+        f"PEPTIDE{i % 20}" for i in range(100)
+    ]  # 20 unique sequences, 100 samples
+    data = {
+        "sequence": sequences,
+        "label": [i % 3 for i in range(100)],
+        "feature": [float(i) for i in range(100)],
+    }
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def imbalanced_dataset():
+    """Create an imbalanced dataset for stratification testing."""
+    from datasets import ClassLabel, Features, Value
+
+    data = {
+        "sequence": [f"PEPTIDE{i}" for i in range(100)],
+        "label": [0] * 70 + [1] * 20 + [2] * 10,  # Imbalanced classes
+        "feature": [float(i) for i in range(100)],
+    }
+
+    # Define features with ClassLabel for stratification
+    features = Features(
+        {
+            "sequence": Value("string"),
+            "label": ClassLabel(names=["class0", "class1", "class2"]),
+            "feature": Value("float32"),
+        }
+    )
+
+    return Dataset.from_dict(data, features=features)
+
+
+# Tests for SplitConfig
+class TestSplitConfig:
+    """Test SplitConfig dataclass validation."""
+
+    def test_default_config(self):
+        """Test default configuration."""
+        config = SplitConfig()
+        assert config.val_ratio == 0.2
+        assert config.test_ratio is None
+        assert config.strategy == SplitStrategy.RANDOM
+        assert config.seed is None
+        assert config.test_uniqueness is True
+
+    def test_invalid_val_ratio(self):
+        """Test validation of val_ratio."""
+        with pytest.raises(ValueError, match="val_ratio must be between 0 and 1"):
+            SplitConfig(val_ratio=1.5)
+
+        with pytest.raises(ValueError, match="val_ratio must be between 0 and 1"):
+            SplitConfig(val_ratio=-0.1)
+
+        with pytest.raises(ValueError, match="val_ratio must be between 0 and 1"):
+            SplitConfig(val_ratio=0)
+
+    def test_invalid_test_ratio(self):
+        """Test validation of test_ratio."""
+        with pytest.raises(ValueError, match="test_ratio must be between 0 and 1"):
+            SplitConfig(test_ratio=1.5)
+
+        with pytest.raises(ValueError, match="test_ratio must be between 0 and 1"):
+            SplitConfig(test_ratio=-0.1)
+
+    def test_invalid_combined_ratios(self):
+        """Test validation when val_ratio + test_ratio >= 1."""
+        with pytest.raises(ValueError, match="val_ratio \\+ test_ratio must be < 1"):
+            SplitConfig(val_ratio=0.6, test_ratio=0.5)
+
+    def test_stratified_without_column(self):
+        """Test that stratified strategy requires stratify_column."""
+        with pytest.raises(ValueError, match="stratify_column must be provided"):
+            SplitConfig(strategy="stratified")
+
+    def test_sequence_unique_without_column(self):
+        """Test that sequence_unique strategy requires sequence_column."""
+        with pytest.raises(ValueError, match="sequence_column must be provided"):
+            SplitConfig(strategy="sequence_unique", sequence_column=None)
+
+    def test_strategy_normalization(self):
+        """Test that strategy string is normalized to enum."""
+        config = SplitConfig(strategy="RANDOM")
+        assert config.strategy == SplitStrategy.RANDOM
+
+        config = SplitConfig(strategy="sequence_unique")
+        assert config.strategy == SplitStrategy.SEQUENCE_UNIQUE
+
+
+# Tests for RandomSplitter
+class TestRandomSplitter:
+    """Test random splitting strategy."""
+
+    def test_two_way_split(self, simple_dataset):
+        """Test basic two-way split (train/val)."""
+        config = SplitConfig(val_ratio=0.2, strategy="random", seed=42)
+        splitter = create_splitter(config)
+
+        result = splitter.split(simple_dataset)
+
+        assert "train" in result
+        assert "val" in result
+        assert "test" not in result
+
+        assert len(result["train"]) == 80
+        assert len(result["val"]) == 20
+        assert len(result["train"]) + len(result["val"]) == len(simple_dataset)
+
+    def test_three_way_split(self, simple_dataset):
+        """Test three-way split (train/val/test)."""
+        config = SplitConfig(val_ratio=0.2, test_ratio=0.1, strategy="random", seed=42)
+        splitter = create_splitter(config)
+
+        result = splitter.split(simple_dataset)
+
+        assert "train" in result
+        assert "val" in result
+        assert "test" in result
+
+        # Test has 10% of data
+        assert len(result["test"]) == 10
+        # Remaining 90 samples split 80/20 for train/val -> ~72/18
+        assert len(result["train"]) + len(result["val"]) == 90
+        assert len(result["train"]) + len(result["val"]) + len(result["test"]) == len(
+            simple_dataset
+        )
+
+    def test_reproducibility(self, simple_dataset):
+        """Test that same seed produces same splits."""
+        config1 = SplitConfig(val_ratio=0.2, strategy="random", seed=42)
+        splitter1 = create_splitter(config1)
+        result1 = splitter1.split(simple_dataset)
+
+        config2 = SplitConfig(val_ratio=0.2, strategy="random", seed=42)
+        splitter2 = create_splitter(config2)
+        result2 = splitter2.split(simple_dataset)
+
+        # Same sequences should be in train/val
+        assert result1["train"]["sequence"] == result2["train"]["sequence"]
+        assert result1["val"]["sequence"] == result2["val"]["sequence"]
+
+    def test_different_seeds(self, simple_dataset):
+        """Test that different seeds produce different splits."""
+        config1 = SplitConfig(val_ratio=0.2, strategy="random", seed=42)
+        splitter1 = create_splitter(config1)
+        result1 = splitter1.split(simple_dataset)
+
+        config2 = SplitConfig(val_ratio=0.2, strategy="random", seed=123)
+        splitter2 = create_splitter(config2)
+        result2 = splitter2.split(simple_dataset)
+
+        # Different sequences should be in train (with high probability)
+        assert result1["train"]["sequence"] != result2["train"]["sequence"]
+
+
+# Tests for StratifiedSplitter
+class TestStratifiedSplitter:
+    """Test stratified splitting strategy."""
+
+    def test_stratified_two_way_split(self, imbalanced_dataset):
+        """Test stratified splitting maintains class distribution."""
+        config = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label", seed=42
+        )
+        splitter = create_splitter(config)
+
+        result = splitter.split(imbalanced_dataset)
+
+        # Check that splits exist
+        assert "train" in result
+        assert "val" in result
+
+        # Calculate class distributions
+        train_labels = result["train"]["label"]
+        val_labels = result["val"]["label"]
+
+        # Original distribution: 70% class 0, 20% class 1, 10% class 2
+        # Check approximate distribution is maintained
+        train_class_0 = sum(1 for l in train_labels if l == 0)
+        train_class_1 = sum(1 for l in train_labels if l == 1)
+        train_class_2 = sum(1 for l in train_labels if l == 2)
+
+        # Should be roughly 70%, 20%, 10%
+        assert 0.65 < train_class_0 / len(train_labels) < 0.75
+        assert 0.15 < train_class_1 / len(train_labels) < 0.25
+        assert 0.05 < train_class_2 / len(train_labels) < 0.15
+
+    def test_stratified_three_way_split(self, imbalanced_dataset):
+        """Test stratified three-way split."""
+        config = SplitConfig(
+            val_ratio=0.15,
+            test_ratio=0.15,
+            strategy="stratified",
+            stratify_column="label",
+            seed=42,
+        )
+        splitter = create_splitter(config)
+
+        result = splitter.split(imbalanced_dataset)
+
+        assert "train" in result
+        assert "val" in result
+        assert "test" in result
+
+        # All samples accounted for
+        total = len(result["train"]) + len(result["val"]) + len(result["test"])
+        assert total == len(imbalanced_dataset)
+
+    def test_stratified_with_invalid_column(self, simple_dataset):
+        """Test error when stratify column doesn't exist."""
+        config = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="nonexistent"
+        )
+        splitter = create_splitter(config)
+
+        with pytest.raises(ValueError, match="Stratification column.*not found"):
+            splitter.split(simple_dataset)
+
+    def test_stratified_reproducibility(self, imbalanced_dataset):
+        """Test reproducibility of stratified splits."""
+        config1 = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label", seed=42
+        )
+        splitter1 = create_splitter(config1)
+        result1 = splitter1.split(imbalanced_dataset)
+
+        config2 = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label", seed=42
+        )
+        splitter2 = create_splitter(config2)
+        result2 = splitter2.split(imbalanced_dataset)
+
+        assert result1["train"]["sequence"] == result2["train"]["sequence"]
+        assert result1["val"]["sequence"] == result2["val"]["sequence"]
+
+
+# Tests for SequenceUniqueSplitter
+class TestSequenceUniqueSplitter:
+    """Test sequence-unique splitting strategy."""
+
+    def test_sequence_unique_two_way_split(self, duplicate_sequence_dataset):
+        """Test that sequences are unique across train/val."""
+        config = SplitConfig(
+            val_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            seed=42,
+        )
+        splitter = create_splitter(config)
+
+        result = splitter.split(duplicate_sequence_dataset)
+
+        # Get unique sequences from each split
+        train_sequences = set(result["train"]["sequence"])
+        val_sequences = set(result["val"]["sequence"])
+
+        # Check no overlap
+        overlap = train_sequences & val_sequences
+        assert len(overlap) == 0, f"Found {len(overlap)} overlapping sequences"
+
+        # Check that splits exist
+        assert len(result["train"]) > 0
+        assert len(result["val"]) > 0
+
+    def test_sequence_unique_three_way_split_with_uniqueness(
+        self, duplicate_sequence_dataset
+    ):
+        """Test three-way split with test uniqueness enabled."""
+        config = SplitConfig(
+            val_ratio=0.2,
+            test_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            test_uniqueness=True,
+            seed=42,
+        )
+        splitter = create_splitter(config)
+
+        result = splitter.split(duplicate_sequence_dataset)
+
+        train_sequences = set(result["train"]["sequence"])
+        val_sequences = set(result["val"]["sequence"])
+        test_sequences = set(result["test"]["sequence"])
+
+        # Check no overlaps
+        assert len(train_sequences & val_sequences) == 0
+        assert len(train_sequences & test_sequences) == 0
+        assert len(val_sequences & test_sequences) == 0
+
+    def test_sequence_unique_with_invalid_column(self, simple_dataset):
+        """Test error when sequence column doesn't exist."""
+        config = SplitConfig(
+            val_ratio=0.2, strategy="sequence_unique", sequence_column="nonexistent"
+        )
+        splitter = create_splitter(config)
+
+        with pytest.raises(ValueError, match="Sequence column.*not found"):
+            splitter.split(simple_dataset)
+
+    def test_sequence_unique_reproducibility(self, duplicate_sequence_dataset):
+        """Test reproducibility of sequence-unique splits."""
+        config1 = SplitConfig(
+            val_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            seed=42,
+        )
+        splitter1 = create_splitter(config1)
+        result1 = splitter1.split(duplicate_sequence_dataset)
+
+        config2 = SplitConfig(
+            val_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            seed=42,
+        )
+        splitter2 = create_splitter(config2)
+        result2 = splitter2.split(duplicate_sequence_dataset)
+
+        # Should produce identical splits
+        train_seq1 = set(result1["train"]["sequence"])
+        train_seq2 = set(result2["train"]["sequence"])
+        assert train_seq1 == train_seq2
+
+    def test_sequence_unique_sample_counts(self, duplicate_sequence_dataset):
+        """Test that samples are correctly distributed across splits."""
+        # Dataset has 20 unique sequences, 100 total samples
+        config = SplitConfig(
+            val_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            seed=42,
+        )
+        splitter = create_splitter(config)
+
+        result = splitter.split(duplicate_sequence_dataset)
+
+        # All samples should be in either train or val
+        total_samples = len(result["train"]) + len(result["val"])
+        assert total_samples == len(duplicate_sequence_dataset)
+
+        # Should have roughly 4 unique sequences in val (20% of 20)
+        val_unique = len(set(result["val"]["sequence"]))
+        train_unique = len(set(result["train"]["sequence"]))
+        assert 3 <= val_unique <= 5  # Allow some variance
+        assert train_unique + val_unique == 20  # All unique sequences accounted for
+
+
+# Tests for create_splitter factory
+class TestCreateSplitter:
+    """Test the create_splitter factory function."""
+
+    def test_create_random_splitter(self):
+        """Test creating a random splitter."""
+        config = SplitConfig(strategy="random")
+        splitter = create_splitter(config)
+        assert isinstance(splitter, RandomSplitter)
+
+    def test_create_stratified_splitter(self):
+        """Test creating a stratified splitter."""
+        config = SplitConfig(strategy="stratified", stratify_column="label")
+        splitter = create_splitter(config)
+        assert isinstance(splitter, StratifiedSplitter)
+
+    def test_create_sequence_unique_splitter(self):
+        """Test creating a sequence-unique splitter."""
+        config = SplitConfig(strategy="sequence_unique")
+        splitter = create_splitter(config)
+        assert isinstance(splitter, SequenceUniqueSplitter)
+
+    def test_invalid_strategy(self):
+        """Test that SplitConfig rejects unknown strategy strings."""
+        with pytest.raises(ValueError):
+            SplitConfig(strategy="invalid_strategy")
+
+
+# Edge cases
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_very_small_dataset(self):
+        """Test splitting a very small dataset."""
+        data = {
+            "sequence": ["PEP1", "PEP2", "PEP3", "PEP4", "PEP5"],
+            "label": [0, 1, 0, 1, 0],
+        }
+        dataset = Dataset.from_dict(data)
+
+        config = SplitConfig(val_ratio=0.2, strategy="random", seed=42)
+        splitter = create_splitter(config)
+        result = splitter.split(dataset)
+
+        assert len(result["train"]) + len(result["val"]) == len(dataset)
+
+    def test_large_val_ratio(self):
+        """Test with large validation ratio."""
+        data = {
+            "sequence": [f"PEP{i}" for i in range(100)],
+            "label": [i % 2 for i in range(100)],
+        }
+        dataset = Dataset.from_dict(data)
+
+        config = SplitConfig(val_ratio=0.8, strategy="random", seed=42)
+        splitter = create_splitter(config)
+        result = splitter.split(dataset)
+
+        assert len(result["val"]) == 80
+        assert len(result["train"]) == 20
+
+    def test_single_unique_sequence(self, simple_dataset):
+        """Test sequence-unique split when all sequences are unique."""
+        # simple_dataset has unique sequences
+        config = SplitConfig(
+            val_ratio=0.2,
+            strategy="sequence_unique",
+            sequence_column="sequence",
+            seed=42,
+        )
+        splitter = create_splitter(config)
+        result = splitter.split(simple_dataset)
+
+        # Should still work correctly
+        assert len(result["train"]) + len(result["val"]) == len(simple_dataset)
+
+        # No overlapping sequences
+        train_seqs = set(result["train"]["sequence"])
+        val_seqs = set(result["val"]["sequence"])
+        assert len(train_seqs & val_seqs) == 0

--- a/tests/test_dataset_splitter.py
+++ b/tests/test_dataset_splitter.py
@@ -76,11 +76,28 @@ class TestSplitConfig:
 
     def test_default_config(self):
         """Test default configuration."""
-        config = SplitConfig()
+        config = SplitConfig(val_ratio=0.2)
         assert config.val_ratio == 0.2
         assert config.test_ratio is None
         assert config.strategy == SplitStrategy.RANDOM
         assert config.seed is None
+
+    def test_both_none_raises(self):
+        """Test that omitting both ratios raises an error."""
+        with pytest.raises(ValueError, match="At least one of val_ratio or test_ratio"):
+            SplitConfig()
+
+    def test_zero_treated_as_none(self):
+        """Test that 0 is normalized to None (skip that split)."""
+        config = SplitConfig(val_ratio=0, test_ratio=0.2)
+        assert config.val_ratio is None
+        assert config.test_ratio == 0.2
+
+    def test_test_ratio_only(self):
+        """Test that providing only test_ratio is valid (train/test split, no val)."""
+        config = SplitConfig(test_ratio=0.2)
+        assert config.val_ratio is None
+        assert config.test_ratio == 0.2
 
     def test_invalid_val_ratio(self):
         """Test validation of val_ratio."""
@@ -89,9 +106,6 @@ class TestSplitConfig:
 
         with pytest.raises(ValueError, match="val_ratio must be between 0 and 1"):
             SplitConfig(val_ratio=-0.1)
-
-        with pytest.raises(ValueError, match="val_ratio must be between 0 and 1"):
-            SplitConfig(val_ratio=0)
 
     def test_invalid_test_ratio(self):
         """Test validation of test_ratio."""
@@ -109,19 +123,19 @@ class TestSplitConfig:
     def test_stratified_without_column(self):
         """Test that stratified strategy requires stratify_column."""
         with pytest.raises(ValueError, match="stratify_column must be provided"):
-            SplitConfig(strategy="stratified")
+            SplitConfig(val_ratio=0.2, strategy="stratified")
 
     def test_sequence_unique_without_column(self):
         """Test that sequence_unique strategy requires sequence_column."""
         with pytest.raises(ValueError, match="sequence_column must be provided"):
-            SplitConfig(strategy="sequence_unique", sequence_column=None)
+            SplitConfig(val_ratio=0.2, strategy="sequence_unique", sequence_column=None)
 
     def test_strategy_normalization(self):
         """Test that strategy string is normalized to enum."""
-        config = SplitConfig(strategy="RANDOM")
+        config = SplitConfig(val_ratio=0.2, strategy="RANDOM")
         assert config.strategy == SplitStrategy.RANDOM
 
-        config = SplitConfig(strategy="sequence_unique")
+        config = SplitConfig(val_ratio=0.2, strategy="sequence_unique")
         assert config.strategy == SplitStrategy.SEQUENCE_UNIQUE
 
 
@@ -143,6 +157,18 @@ class TestRandomSplitter:
         assert len(result["train"]) == 80
         assert len(result["val"]) == 20
         assert len(result["train"]) + len(result["val"]) == len(simple_dataset)
+
+    def test_train_test_split(self, simple_dataset):
+        """Test two-way train/test split (no val)."""
+        config = SplitConfig(test_ratio=0.2, strategy="random", seed=42)
+        splitter = create_splitter(config)
+
+        result = splitter.split(simple_dataset)
+
+        assert "train" in result
+        assert "test" in result
+        assert "val" not in result
+        assert len(result["train"]) + len(result["test"]) == len(simple_dataset)
 
     def test_three_way_split(self, simple_dataset):
         """Test three-way split (train/val/test)."""
@@ -253,6 +279,32 @@ class TestStratifiedSplitter:
 
         with pytest.raises(ValueError, match="Stratification column.*not found"):
             splitter.split(simple_dataset)
+
+    def test_stratified_auto_casts_non_classlabel_column(self):
+        """Test that a plain int column is auto-cast to ClassLabel with a warning."""
+        import warnings
+
+        from datasets import Dataset
+
+        data = {
+            "sequence": [f"PEP{i}" for i in range(100)],
+            "label": [i % 3 for i in range(100)],  # plain int64, not ClassLabel
+        }
+        dataset = Dataset.from_dict(data)
+        assert not hasattr(dataset.features["label"], "names")  # confirm not ClassLabel
+
+        config = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label", seed=42
+        )
+        splitter = create_splitter(config)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = splitter.split(dataset)
+
+        assert any("Auto-casting" in str(w.message) for w in caught)
+        assert "train" in result and "val" in result
+        assert len(result["train"]) + len(result["val"]) == len(dataset)
 
     def test_stratified_reproducibility(self, imbalanced_dataset):
         """Test reproducibility of stratified splits."""
@@ -389,19 +441,21 @@ class TestCreateSplitter:
 
     def test_create_random_splitter(self):
         """Test creating a random splitter."""
-        config = SplitConfig(strategy="random")
+        config = SplitConfig(val_ratio=0.2, strategy="random")
         splitter = create_splitter(config)
         assert isinstance(splitter, RandomSplitter)
 
     def test_create_stratified_splitter(self):
         """Test creating a stratified splitter."""
-        config = SplitConfig(strategy="stratified", stratify_column="label")
+        config = SplitConfig(
+            val_ratio=0.2, strategy="stratified", stratify_column="label"
+        )
         splitter = create_splitter(config)
         assert isinstance(splitter, StratifiedSplitter)
 
     def test_create_sequence_unique_splitter(self):
         """Test creating a sequence-unique splitter."""
-        config = SplitConfig(strategy="sequence_unique")
+        config = SplitConfig(val_ratio=0.2, strategy="sequence_unique")
         splitter = create_splitter(config)
         assert isinstance(splitter, SequenceUniqueSplitter)
 

--- a/tests/test_dataset_splitter.py
+++ b/tests/test_dataset_splitter.py
@@ -81,7 +81,6 @@ class TestSplitConfig:
         assert config.test_ratio is None
         assert config.strategy == SplitStrategy.RANDOM
         assert config.seed is None
-        assert config.test_uniqueness is True
 
     def test_invalid_val_ratio(self):
         """Test validation of val_ratio."""
@@ -310,7 +309,6 @@ class TestSequenceUniqueSplitter:
             test_ratio=0.2,
             strategy="sequence_unique",
             sequence_column="sequence",
-            test_uniqueness=True,
             seed=42,
         )
         splitter = create_splitter(config)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,6 +3,7 @@ import time
 from os.path import join
 from shutil import rmtree
 
+import pytest
 from datasets import Dataset, DatasetDict, load_dataset
 
 from dlomix.data import (
@@ -209,13 +210,14 @@ def test_nested_model_features(raw_generic_nested_data):
         sequence_column="seq",
         label_column="label",
         model_features=["nested_feature"],
+        val_ratio=0.5,
     )
 
     assert intensity_dataset.hf_dataset is not None
     assert intensity_dataset._empty_dataset_mode is False
 
     example = iter(intensity_dataset.tensor_train_data).next()
-    assert example[0]["nested_feature"].shape == [2, 1, 2]
+    assert example[0]["nested_feature"].shape == [1, 1, 2]
 
 
 def test_save_dataset(raw_generic_nested_data):
@@ -515,3 +517,108 @@ def test_tf_tensor_dataset_list_multi_label(raw_generic_nested_data):
         features, labels = batch
         assert features is not None
         assert labels is not None
+
+
+# Integration tests for dataset splitter
+def test_rtdataset_with_random_splitter(download_path_for_assets):
+    """Test RetentionTimeDataset with random splitting strategy."""
+    rtdataset = RetentionTimeDataset(
+        data_source=join(download_path_for_assets, "file_2.csv"),
+        data_format="csv",
+        sequence_column="sequence",
+        label_column="irt",
+        val_ratio=0.2,
+        split_strategy="random",
+        split_seed=42,
+    )
+
+    assert rtdataset.hf_dataset is not None
+    assert "train" in rtdataset.hf_dataset
+    assert "val" in rtdataset.hf_dataset
+    assert rtdataset["train"].num_rows > 0
+    assert rtdataset["val"].num_rows > 0
+
+
+def test_rtdataset_with_three_way_split(download_path_for_assets):
+    """Test RetentionTimeDataset with three-way split (train/val/test)."""
+    rtdataset = RetentionTimeDataset(
+        data_source=join(download_path_for_assets, "file_2.csv"),
+        data_format="csv",
+        sequence_column="sequence",
+        label_column="irt",
+        val_ratio=0.15,
+        test_ratio=0.15,  # Fixed: was split_test_ratio
+        split_strategy="random",
+        split_seed=42,
+    )
+
+    assert rtdataset.hf_dataset is not None
+    assert "train" in rtdataset.hf_dataset
+    assert "val" in rtdataset.hf_dataset
+    assert "test" in rtdataset.hf_dataset
+    assert rtdataset["train"].num_rows > 0
+    assert rtdataset["val"].num_rows > 0
+    assert rtdataset["test"].num_rows > 0
+
+
+def test_rtdataset_with_sequence_unique_splitter(download_path_for_assets):
+    """Test RetentionTimeDataset with sequence-unique splitting."""
+    # Use a dataset from HF directly to avoid the processing step modifying sequences
+    from datasets import load_dataset as hf_load_dataset
+
+    hf_data = hf_load_dataset(
+        "csv",
+        data_files=join(download_path_for_assets, "file_2.csv"),
+        split="train",
+    )
+
+    rtdataset = RetentionTimeDataset(
+        data_source=hf_data,
+        data_format="hf",
+        sequence_column="sequence",
+        label_column="irt",
+        val_ratio=0.2,
+        split_strategy="sequence_unique",
+        split_seed=42,
+    )
+
+    assert rtdataset.hf_dataset is not None
+
+    # Note: After processing, sequence column is still present but may be modified
+    # We verify the split happened correctly by checking dataset existence
+    assert "train" in rtdataset.hf_dataset
+    assert "val" in rtdataset.hf_dataset
+    assert rtdataset["train"].num_rows > 0
+    assert rtdataset["val"].num_rows > 0
+
+
+def test_rtdataset_backward_compatibility(download_path_for_assets):
+    """Test that existing code without split parameters still works (backward compatibility)."""
+    # This is the old way of creating a dataset - should still work
+    rtdataset = RetentionTimeDataset(
+        data_source=join(download_path_for_assets, "file_2.csv"),
+        data_format="csv",
+        sequence_column="sequence",
+        label_column="irt",
+        val_ratio=0.2,  # Only val_ratio, no other split parameters
+    )
+
+    assert rtdataset.hf_dataset is not None
+    assert "train" in rtdataset.hf_dataset
+    assert "val" in rtdataset.hf_dataset
+    assert rtdataset["train"].num_rows > 0
+    assert rtdataset["val"].num_rows > 0
+
+
+def test_rtdataset_split_config_conflict(download_path_for_assets):
+    """Test that providing both predefined splits and split config raises error."""
+    with pytest.raises(ValueError, match="Cannot use split configuration parameters"):
+        RetentionTimeDataset(
+            data_source=join(download_path_for_assets, "file_2.csv"),
+            val_data_source=join(download_path_for_assets, "file_2.csv"),
+            data_format="csv",
+            sequence_column="sequence",
+            label_column="irt",
+            split_strategy="sequence_unique",  # Conflict: predefined val_data_source + split_strategy
+            split_seed=42,
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -53,6 +53,7 @@ def test_parquet_rtdataset(download_path_for_assets):
         data_source=join(download_path_for_assets, "file_1.parquet"),
         sequence_column="modified_sequence",
         label_column="indexed_retention_time",
+        val_ratio=0.2,
     )
     assert rtdataset.hf_dataset is not None
     assert rtdataset._empty_dataset_mode is False
@@ -81,6 +82,7 @@ def test_rtdataset_inmemory(download_path_for_assets):
         data_format="hf",
         sequence_column="modified_sequence",
         label_column="indexed_retention_time",
+        val_ratio=0.2,
     )
     assert rtdataset.hf_dataset is not None
     assert rtdataset._empty_dataset_mode is False
@@ -148,6 +150,7 @@ def test_parquet_intensitydataset(download_path_for_assets):
         sequence_column="sequence",
         label_column="intensities",
         model_features=["precursor_charge_onehot", "collision_energy_aligned_normed"],
+        val_ratio=0.2,
     )
 
     assert intensity_dataset.hf_dataset is not None
@@ -178,6 +181,7 @@ def test_csv_intensitydataset(download_path_for_assets):
         data_source=filepath,
         sequence_column="sequence",
         label_column="intensities",
+        val_ratio=0.2,
     )
 
     assert intensity_dataset.hf_dataset is not None
@@ -229,6 +233,7 @@ def test_save_dataset(raw_generic_nested_data):
         sequence_column="seq",
         label_column="label",
         model_features=["nested_feature"],
+        val_ratio=0.1,
     )
 
     save_path = "./.test_dataset_2"
@@ -399,6 +404,7 @@ def test_shuffle_parameter(raw_generic_nested_data):
         dataset_type="tf",
         shuffle=True,
         batch_size=1,
+        val_ratio=0.2,
     )
 
     # Test with shuffle=True for PyTorch
@@ -410,6 +416,7 @@ def test_shuffle_parameter(raw_generic_nested_data):
         dataset_type="pt",
         shuffle=True,
         batch_size=1,
+        val_ratio=0.2,
     )
 
     # Verify datasets are created successfully
@@ -430,6 +437,7 @@ def test_torch_dataloader_kwargs(raw_generic_nested_data):
         label_column="label",
         dataset_type="pt",
         batch_size=1,
+        val_ratio=0.2,
         torch_dataloader_kwargs={
             "drop_last": True,
             "pin_memory": False,
@@ -458,6 +466,7 @@ def test_tf_tensor_dataset_string_label(raw_generic_nested_data):
         label_column="label",
         dataset_type="tf",
         batch_size=1,
+        val_ratio=0.2,
     )
 
     # Get the TensorFlow dataset
@@ -482,6 +491,7 @@ def test_tf_tensor_dataset_singelton_list_label(raw_generic_nested_data):
         label_column=["label"],
         dataset_type="tf",
         batch_size=1,
+        val_ratio=0.2,
     )
 
     # Get the TensorFlow dataset
@@ -506,6 +516,7 @@ def test_tf_tensor_dataset_list_multi_label(raw_generic_nested_data):
         label_column=["label", "label2"],
         dataset_type="tf",
         batch_size=1,
+        val_ratio=0.2,
     )
 
     # Get the TensorFlow dataset

--- a/tests/test_inference_pipeline.py
+++ b/tests/test_inference_pipeline.py
@@ -1,0 +1,219 @@
+"""Tests for InferencePipeline (model + preprocessor bundling)."""
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+from datasets import Dataset
+
+from dlomix.config import _BACKEND, PYTORCH_BACKEND
+from dlomix.data import PeptidePreprocessor, RetentionTimeDataset
+from dlomix.models import PrositRetentionTimePredictor
+from dlomix.pipelines import InferencePipeline
+
+DATASET_TYPE = "pt" if _BACKEND in PYTORCH_BACKEND else "tf"
+
+_CARD_ALPHABET = {
+    "-": 0,
+    "X": 1,
+    "A": 2,
+    "C": 3,
+    "D": 4,
+    "E": 5,
+    "K": 6,
+    "P": 7,
+    "M": 8,
+}
+
+
+class _FakeModel:
+    """Stand-in model with no embedding (consistency check is skipped)."""
+
+
+def _make_card(tmp_path, **prep_kwargs) -> str:
+    prep = PeptidePreprocessor(
+        alphabet=_CARD_ALPHABET,
+        sequence_column="modified_sequence",
+        max_seq_len=30,
+        dataset_type=DATASET_TYPE,
+        **prep_kwargs,
+    )
+    pipe = InferencePipeline(_FakeModel(), prep)
+    pipe._write_model_card(str(tmp_path), "omsh/test-model")
+    return (tmp_path / "README.md").read_text()
+
+
+RAW_SEQUENCES = [
+    "ACDEFGHIK",
+    "PEPTIDEK",
+    "MKLVAAR",
+    "GGGGSSSK",
+    "ACDEFGHIKLMN",
+    "PEPK",
+    "MMMKL",
+    "AAACCCDDD",
+    "KKLLMMNN",
+    "PPQQRRSS",
+]
+
+
+@pytest.fixture
+def rt_dataset():
+    seqs = RAW_SEQUENCES * 4
+    data = {
+        "modified_sequence": seqs,
+        "indexed_retention_time": [float(len(s)) for s in seqs],
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return RetentionTimeDataset(
+            data_source=Dataset.from_dict(data),
+            data_format="hf",
+            sequence_column="modified_sequence",
+            label_column="indexed_retention_time",
+            val_ratio=0.2,
+            max_seq_len=20,
+            batch_size=8,
+            dataset_type=DATASET_TYPE,
+        )
+
+
+@pytest.fixture
+def rt_model(rt_dataset):
+    model = PrositRetentionTimePredictor(
+        seq_length=22, alphabet=rt_dataset.extended_alphabet
+    )
+    # build/initialize parameters on real tensors
+    if DATASET_TYPE == "pt":
+        import torch
+
+        batch = next(iter(rt_dataset.tensor_train_data))
+        with torch.no_grad():
+            model(batch["modified_sequence"])
+    else:
+        model.predict(rt_dataset.tensor_train_data, verbose=0)
+    return model
+
+
+def test_predict_on_raw_sequences(rt_dataset, rt_model):
+    pipe = InferencePipeline.from_model_and_dataset(rt_model, rt_dataset)
+    preds = pipe.predict(["ACDEFGHIK", "PEPTIDEK"])
+    assert preds.shape[0] == 2
+    assert np.isfinite(preds).all()
+
+
+def test_consistency_check_rejects_mismatched_model(rt_dataset):
+    # model built with a deliberately different (smaller) vocabulary
+    small_alphabet = {"-": 0, "X": 1, "A": 2, "C": 3}
+    bad_model = PrositRetentionTimePredictor(seq_length=22, alphabet=small_alphabet)
+    with pytest.raises(ValueError, match="Model/preprocessor mismatch"):
+        InferencePipeline.from_model_and_dataset(bad_model, rt_dataset)
+
+
+def test_save_load_reproduces_predictions(rt_dataset, rt_model, tmp_path):
+    pipe = InferencePipeline.from_model_and_dataset(rt_model, rt_dataset)
+    seqs = ["ACDEFGHIK", "PEPTIDEK", "MKLVAAR"]
+    before = pipe.predict(seqs)
+
+    save_dir = str(tmp_path / "bundle")
+    pipe.save(save_dir)
+
+    loaded = InferencePipeline.load(save_dir)
+    after = loaded.predict(seqs)
+
+    assert before.shape == after.shape
+    np.testing.assert_allclose(before, after, rtol=1e-4, atol=1e-4)
+
+
+def test_save_refuses_existing_nonempty_dir(rt_dataset, rt_model, tmp_path):
+    pipe = InferencePipeline.from_model_and_dataset(rt_model, rt_dataset)
+    save_dir = tmp_path / "bundle"
+    save_dir.mkdir()
+    (save_dir / "sentinel.txt").write_text("x")
+    with pytest.raises(FileExistsError):
+        pipe.save(str(save_dir))
+    # overwrite=True succeeds
+    assert pipe.save(str(save_dir), overwrite=True)
+
+
+def test_push_to_hub_uploads_bundle(rt_dataset, rt_model, tmp_path, monkeypatch):
+    """push_to_hub writes the full bundle + model card and uploads the folder."""
+    import huggingface_hub
+
+    pipe = InferencePipeline.from_model_and_dataset(rt_model, rt_dataset)
+    captured = {}
+
+    def fake_create_repo(repo_id, **kwargs):
+        captured["repo_id"] = repo_id
+
+    class FakeApi:
+        def __init__(self, token=None):
+            captured["token"] = token
+
+        def upload_folder(self, repo_id, folder_path, commit_message=None, **kwargs):
+            captured["folder"] = folder_path
+            captured["delete_patterns"] = kwargs.get("delete_patterns")
+            captured["files"] = sorted(p.name for p in Path(folder_path).iterdir())
+
+    monkeypatch.setattr(huggingface_hub, "create_repo", fake_create_repo)
+    monkeypatch.setattr(huggingface_hub, "HfApi", FakeApi)
+
+    pipe.push_to_hub("user/rt-model", token="hf_dummy")
+
+    assert captured["repo_id"] == "user/rt-model"
+    assert "README.md" in captured["files"]
+    assert "dlomix_inference_pipeline.json" in captured["files"]
+    assert "dlomix_preprocessor.json" in captured["files"]
+    assert any(f.startswith("model.") for f in captured["files"])
+    # mirrors the repo to the bundle (drops stale files from prior pushes)
+    assert captured["delete_patterns"] == "*"
+
+
+def test_from_pretrained_delegates_to_load(rt_dataset, rt_model, tmp_path, monkeypatch):
+    """from_pretrained downloads the snapshot then reuses load()."""
+    import huggingface_hub
+
+    pipe = InferencePipeline.from_model_and_dataset(rt_model, rt_dataset)
+    save_dir = str(tmp_path / "snapshot")
+    pipe.save(save_dir)
+
+    monkeypatch.setattr(
+        huggingface_hub, "snapshot_download", lambda repo_id, **kwargs: save_dir
+    )
+
+    loaded = InferencePipeline.from_pretrained("user/rt-model")
+    preds = loaded.predict(["ACDEFGHIK", "PEPTIDEK"])
+    assert preds.shape[0] == 2
+
+
+def test_model_card_seq_only_uses_plain_list(tmp_path):
+    card = _make_card(tmp_path)
+    assert 'pipeline.predict(["PEPTIDEK"' in card
+    assert "predict({" not in card  # no dict form for a sequence-only model
+    assert "requires the feature column" not in card
+
+
+def test_model_card_with_model_features_uses_dict(tmp_path):
+    card = _make_card(
+        tmp_path,
+        model_features=["collision_energy_aligned_normed", "precursor_charge_onehot"],
+    )
+    assert "predict({" in card
+    assert '"modified_sequence":' in card
+    assert '"collision_energy_aligned_normed": [...]' in card
+    assert '"precursor_charge_onehot": [...]' in card
+    assert "requires the feature column(s)" in card
+
+
+def test_model_card_notes_extracted_ptm_features(tmp_path):
+    card = _make_card(
+        tmp_path,
+        model_features=["collision_energy_aligned_normed"],
+        features_to_extract=["mod_loss", "delta_mass"],
+    )
+    # extracted features are computed, not supplied -> not in the predict() dict
+    assert '"mod_loss"' not in card
+    assert '"delta_mass"' not in card
+    assert "computed from the sequence automatically" in card
+    assert "`mod_loss`, `delta_mass`" in card

--- a/tests/test_inference_preprocessor.py
+++ b/tests/test_inference_preprocessor.py
@@ -1,0 +1,155 @@
+"""Tests for PeptidePreprocessor (reusable inference preprocessing)."""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+from datasets import Dataset
+
+from dlomix.config import _BACKEND, PYTORCH_BACKEND
+from dlomix.data import PeptidePreprocessor, RetentionTimeDataset
+
+DATASET_TYPE = "pt" if _BACKEND in PYTORCH_BACKEND else "tf"
+
+RAW_SEQUENCES = [
+    "ACDEFGHIK",
+    "PEPTIDEK",
+    "MKLVAAR",
+    "GGGGSSSK",
+    "ACDEFGHIKLMN",
+    "PEPK",
+    "MMMKL",
+    "AAACCCDDD",
+    "KKLLMMNN",
+    "PPQQRRSS",
+]
+
+
+@pytest.fixture
+def rt_dataset():
+    seqs = RAW_SEQUENCES * 4
+    data = {
+        "modified_sequence": seqs,
+        "indexed_retention_time": [float(len(s)) for s in seqs],
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return RetentionTimeDataset(
+            data_source=Dataset.from_dict(data),
+            data_format="hf",
+            sequence_column="modified_sequence",
+            label_column="indexed_retention_time",
+            val_ratio=0.2,
+            max_seq_len=20,
+            batch_size=8,
+            dataset_type=DATASET_TYPE,
+        )
+
+
+def _first_batch_seq(tensors, seq_col):
+    """Extract the first batch's sequence tensor as numpy, for tf or torch outputs."""
+    batch = next(iter(tensors))
+    arr = batch[seq_col] if isinstance(batch, dict) else batch
+    return np.asarray(arr)
+
+
+def test_get_preprocessor_returns_preprocessor(rt_dataset):
+    prep = rt_dataset.get_preprocessor()
+    assert isinstance(prep, PeptidePreprocessor)
+    assert prep.sequence_column == "modified_sequence"
+    assert prep.max_seq_len == 20
+    assert prep.vocab_size == len(rt_dataset.extended_alphabet)
+    assert prep.dataset_type == DATASET_TYPE
+
+
+def test_transform_shape(rt_dataset):
+    prep = rt_dataset.get_preprocessor()
+    seqs = ["ACDEFGHIK", "PEPTIDEK"]
+    out = prep(seqs)
+    arr = _first_batch_seq(out, prep.sequence_column)
+    # with_termini -> max_seq_len + 2 columns
+    assert arr.shape == (2, 22)
+
+
+def test_single_string_input(rt_dataset):
+    prep = rt_dataset.get_preprocessor()
+    arr = _first_batch_seq(prep("ACDEFGHIK"), prep.sequence_column)
+    assert arr.shape == (1, 22)
+
+
+def test_input_formats_equivalent(rt_dataset):
+    prep = rt_dataset.get_preprocessor()
+    seqs = ["ACDEFGHIK", "PEPTIDEK"]
+
+    from_list = _first_batch_seq(prep(seqs), prep.sequence_column)
+    from_np = _first_batch_seq(prep(np.array(seqs)), prep.sequence_column)
+    from_dict = _first_batch_seq(
+        prep({prep.sequence_column: seqs}), prep.sequence_column
+    )
+    from_df = _first_batch_seq(
+        prep(pd.DataFrame({prep.sequence_column: seqs})), prep.sequence_column
+    )
+    from_hf = _first_batch_seq(
+        prep(Dataset.from_dict({prep.sequence_column: seqs})), prep.sequence_column
+    )
+
+    for other in (from_np, from_dict, from_df, from_hf):
+        np.testing.assert_array_equal(from_list, other)
+
+
+def test_encoding_matches_alphabet(rt_dataset):
+    """The encoded sequence uses the dataset's learned alphabet + padding."""
+    prep = rt_dataset.get_preprocessor()
+    alphabet = rt_dataset.extended_alphabet
+    arr = _first_batch_seq(prep(["ACDEK"]), prep.sequence_column)
+
+    expected_tokens = ["[]-", "A", "C", "D", "E", "K", "-[]"]
+    expected_ids = [alphabet[t] for t in expected_tokens]
+    pad_id = alphabet[prep.padding_value]
+
+    assert list(arr[0, : len(expected_ids)]) == expected_ids
+    assert set(arr[0, len(expected_ids) :]) == {pad_id}
+
+
+def test_missing_sequence_column_raises(rt_dataset):
+    prep = rt_dataset.get_preprocessor()
+    with pytest.raises(ValueError, match="Sequence column.*not found"):
+        prep({"wrong_column": ["ACDEK"]})
+
+
+def test_save_load_roundtrip(rt_dataset, tmp_path):
+    prep = rt_dataset.get_preprocessor()
+    artifact = prep.save(str(tmp_path / "prep"))
+
+    loaded = PeptidePreprocessor.load(artifact)
+    assert loaded.fingerprint == prep.fingerprint
+    assert loaded.alphabet == prep.alphabet
+    assert loaded.max_seq_len == prep.max_seq_len
+
+    a = _first_batch_seq(prep(["PEPTIDEK"]), prep.sequence_column)
+    b = _first_batch_seq(loaded(["PEPTIDEK"]), loaded.sequence_column)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_from_saved_dataset_dir(rt_dataset, tmp_path):
+    save_dir = str(tmp_path / "dataset")
+    rt_dataset.save_to_disk(save_dir)
+
+    prep = PeptidePreprocessor.from_saved(save_dir)
+    assert prep.vocab_size == len(rt_dataset.extended_alphabet)
+
+    live = rt_dataset.get_preprocessor()
+    a = _first_batch_seq(prep(["PEPTIDEK"]), prep.sequence_column)
+    b = _first_batch_seq(live(["PEPTIDEK"]), live.sequence_column)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_manual_construction_requires_padding_in_alphabet():
+    with pytest.raises(ValueError, match="padding_value.*not present"):
+        PeptidePreprocessor(
+            alphabet={"A": 2, "C": 3},  # no padding token
+            sequence_column="seq",
+            max_seq_len=10,
+            dataset_type=DATASET_TYPE,
+        )

--- a/tests/test_torch_dataset.py
+++ b/tests/test_torch_dataset.py
@@ -21,6 +21,7 @@ def test_dataset_torch(raw_generic_nested_data):
         batch_size=2,
         max_seq_len=15,
         with_termini=False,
+        val_ratio=0.5,
     )
 
     logger.info(intensity_dataset)
@@ -31,10 +32,10 @@ def test_dataset_torch(raw_generic_nested_data):
 
     logger.info(batch)
 
-    assert list(batch["nested_feature"].shape) == [2, 1, 2]
-    assert list(batch["seq"].shape) == [2, 15]
+    assert list(batch["nested_feature"].shape) == [1, 1, 2]
+    assert list(batch["seq"].shape) == [1, 15]
     assert list(batch["label"].shape) == [
-        2,
+        1,
     ]
 
     assert batch["seq"].dtype == torch.int64


### PR DESCRIPTION
## Dataset Refactoring + Inference Pipeline


### 1. Dataset internals refactoring
- Extracted loading, serialization, tensor conversion, and processing pipeline into dedicated modules (`loading.py`, `serialization.py`, `tensor_conversion.py`, `processing/chain.py`, `processing/pipeline.py`)
- `PeptideDataset.__init__` now delegates to these — significantly reduced in size
- Processors own their split-specific behavior via `apply_to_split` (vocab learning, truncation filtering) instead of the dataset special-casing them
- `StratifiedSplitter` now handles ClassLabel, scalar, and list/one-hot columns; better error messages
- Removed the stray `print()` from `processing/__init__`; added `available_feature_extractors()` as a proper public function

### 2. Inference pipeline
- `PeptidePreprocessor`: captures a dataset's preprocessing recipe and applies it to raw inputs (string, list, numpy, DataFrame, HF Dataset) → tf/torch tensors. Save/load as a lightweight JSON artifact.
- `InferencePipeline`: bundles a model + preprocessor for one-call `predict()`; validates model/preprocessor consistency; `save/load` and `push_to_hub/from_pretrained` for HF Hub sharing with auto-generated model card
- `dataset.get_preprocessor()` as the bridge between training and inference
- Both use `processing/chain.py` as a single source of truth so inference preprocessing cannot drift from training
