### PR TITLE
Replace np.round_ with np.round for rounding

### DIFF
--- a/src/dlomix/reports/DetectabilityReport.py
+++ b/src/dlomix/reports/DetectabilityReport.py
@@ -156,7 +156,7 @@ class DetectabilityReport(Report):
         )
 
         for i, label in enumerate(CLASSES_LABELS):
-            df_data_results[label] = np.round_(
+            df_data_results[label] = np.round(
                 np.array(self.results_metrics_dict["probabilities"])[:, i], decimals=3
             )
 
@@ -724,7 +724,7 @@ class predictions_report:
         )
 
         for i, label in enumerate(CLASSES_LABELS):
-            df_data_results[label] = np.round_(
+            df_data_results[label] = np.round(
                 np.array(self.predictions)[:, i], decimals=3
             )
 
@@ -734,7 +734,7 @@ class predictions_report:
             + df_data_results["Strong Flyer"]
         )
         # df_data_results['Flyer'] = round(df_data_results['Flyer'], ndigits = 3)
-        df_data_results["Flyer"] = np.round_(df_data_results["Flyer"], decimals=3)
+        df_data_results["Flyer"] = np.round(df_data_results["Flyer"], decimals=3)
         df_data_results["Binary Predictions"] = np.where(
             df_data_results["Predictions"] == 0, 0, 1
         )


### PR DESCRIPTION
Type of change: Bug fix / Compatibility update.

Replace deprecated `np.round_` calls with `np.round` for NumPy 2.0 compatibility.

`np.round_` was removed in NumPy 2.0 as part of the namespace cleanup, while `np.round` provides the same functionality. This change updates the affected calls in `DetectabilityReport.py` without altering behavior and maintains compatibility with both NumPy 1.x and 2.x. [[numpy.org]](https://numpy.org/devdocs/release/2.0.0-notes.html), [[docs.astral.sh]](https://docs.astral.sh/ruff/rules/numpy2-deprecation/)